### PR TITLE
Combine success and error messages together

### DIFF
--- a/src/PresentationalComponents/Email/Email.js
+++ b/src/PresentationalComponents/Email/Email.js
@@ -77,12 +77,15 @@ const Email = () => {
     const saveValues = async ({ unsubscribe, ...values }) => {
         const promises = Object.entries(emailConfig)
         .filter(([ , { isVisible }]) => isVisible === true)
-        .map(([ application, { localFile, title, schema, url }]) => {
+        .map(([ application, { localFile, schema, url }]) => {
             if (!localFile && !schema && store?.[application]?.schema && Object.keys(store?.[application]?.schema).length > 0) {
-                const action = saveEmailValues({ application, values, url, title });
+                const action = saveEmailValues({ application, values, url });
                 dispatch(action);
 
-                return action.payload;
+                return {
+                    promise: action.payload,
+                    meta: action.meta
+                };
             }
         }).filter(Boolean);
 

--- a/src/SmartComponents/FormComponents/DescriptiveCheckbox.js
+++ b/src/SmartComponents/FormComponents/DescriptiveCheckbox.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import './descriptiveCheckbox.scss';
 
 // eslint-disable-next-line no-unused-vars
-const DescriptiveCheckbox = ({ name, label, description, isDanger, FieldProvider, isGlobal, ...rest }) => {
+const DescriptiveCheckbox = ({ name, label, title, description, isDanger, FieldProvider, isGlobal, ...rest }) => {
     return (
         <FieldProvider name={ name } data={ {
             isClearable: true
@@ -35,7 +35,7 @@ const DescriptiveCheckbox = ({ name, label, description, isDanger, FieldProvider
                 label={ <span className={ classNames(
                     'pref-c-checkbox-label',
                     { 'pref-c-checkbox-label-error': isDanger || isGlobal }
-                ) }>{label}</span> }
+                ) }>{label || title}</span> }
                 { ...description && { description: <span className="pref-c-checkbox-description">{description}</span> } }
             />
         ) }
@@ -48,6 +48,7 @@ DescriptiveCheckbox.propTypes = {
     formOptions: PropTypes.any,
     name: PropTypes.string,
     label: PropTypes.string,
+    title: PropTypes.string,
     description: PropTypes.string,
     isDanger: PropTypes.bool,
     isGlobal: PropTypes.bool

--- a/src/Utilities/functions.js
+++ b/src/Utilities/functions.js
@@ -57,13 +57,13 @@ export const getSection = (key, schema = {}, storeSchema, success = () => {}) =>
 };
 
 export const concatApps = (apps = []) => {
-    return apps.reduce((acc, title, currentIndex) => (
-        `${acc}${title}${
-            currentIndex < apps.length - 1 ?
-                currentIndex < apps.length - 2 ? ',' : ' and'
-                : ''
-        } `
-    ), '');
+    return `${
+        apps.slice(0, apps.length - (apps.length > 1)).join(', ')
+    }${
+        apps.length >= 2 ?
+            ` and ${apps[apps.length - 1]}`
+            : ''
+    }`;
 };
 
 export const distributeSuccessError = (promisses = []) => {
@@ -83,15 +83,13 @@ export const dispatchMessages = (dispatch = () => undefined, success = [], error
         dispatch(addNotification({
             dismissable: false,
             variant: 'success',
-            title: 'Preferences successfully saved',
-            description: `User's configuration email for ${concatApps(success)} were successfully saved.`
+            title: `Email preferences for ${concatApps(success)} successfully saved`
         }));
 
         dispatch(addNotification({
             dismissable: false,
             variant: 'danger',
-            title: 'Preferences unsuccessfully saved',
-            description: `User's configuration email for ${concatApps(error)} were unsuccessfully saved.`
+            title: `Email preferences for ${concatApps(error)} unsuccessfully saved`
         }));
     }
 

--- a/src/Utilities/functions.js
+++ b/src/Utilities/functions.js
@@ -56,8 +56,8 @@ export const getSection = (key, schema = {}, storeSchema, success = () => {}) =>
     }
 };
 
-export const concatApps = (apps) => {
-    return apps.reduce((acc, { title }, currentIndex) => (
+export const concatApps = (apps = []) => {
+    return apps.reduce((acc, title, currentIndex) => (
         `${acc}${title}${
             currentIndex < apps.length - 1 ?
                 currentIndex < apps.length - 2 ? ',' : ' and'
@@ -66,19 +66,19 @@ export const concatApps = (apps) => {
     ), '');
 };
 
-export const distributeSuccessError = (promisses) =>{
-    return Promise.allSettled(promisses).then((apps) => {
-        return apps.reduce((acc, { value, reason }) => ({
+export const distributeSuccessError = (promisses = []) => {
+    return Promise.allSettled(promisses.map(({ promise } = {}) => promise)).then((apps) => {
+        return apps.reduce((acc, { value }, index) => ({
             ...acc,
             [value ? 'success' : 'error']: [
                 ...acc[value ? 'success' : 'error'],
-                value || reason
+                promisses[index]?.meta?.title
             ]
         }), { success: [], error: []});
     });
 };
 
-export const dispatchMessages = (dispatch, success, error = []) => {
+export const dispatchMessages = (dispatch = () => undefined, success = [], error = []) => {
     if (error.length !== 0 && success.length !== 0) {
         dispatch(addNotification({
             dismissable: false,

--- a/src/Utilities/functions.test.js
+++ b/src/Utilities/functions.test.js
@@ -173,17 +173,17 @@ describe('concatApps', () => {
 
     it('should concat one app', () => {
         const apps = concatApps([ 'one' ]);
-        expect(apps).toBe('one ');
+        expect(apps).toBe('one');
     });
 
     it('should concat two apps', () => {
         const apps = concatApps([ 'one', 'two' ]);
-        expect(apps).toBe('one and two ');
+        expect(apps).toBe('one and two');
     });
 
     it('should concat multiple apps', () => {
         const apps = concatApps([ 'one', 'two', 'three' ]);
-        expect(apps).toBe('one, two and three ');
+        expect(apps).toBe('one, two and three');
     });
 });
 
@@ -273,16 +273,14 @@ describe('dispatchMessages', () => {
         expect(dispatch.mock.calls[0][0]).toMatchObject({
             payload: {
                 dismissable: false,
-                title: 'Preferences successfully saved',
-                description: `User's configuration email for some, message and multiple  were successfully saved.`,
+                title: 'Email preferences for some, message and multiple successfully saved',
                 variant: 'success'
             }
         });
         expect(dispatch.mock.calls[1][0]).toMatchObject({
             payload: {
                 dismissable: false,
-                title: 'Preferences unsuccessfully saved',
-                description: `User's configuration email for some, message and multiple  were unsuccessfully saved.`,
+                title: 'Email preferences for some, message and multiple unsuccessfully saved',
                 variant: 'danger'
             }
         });

--- a/src/Utilities/functions.test.js
+++ b/src/Utilities/functions.test.js
@@ -1,6 +1,14 @@
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
-import { getSchema, getSection, calculatePermissions, calculateEmailConfig } from './functions';
+import {
+    getSchema,
+    getSection,
+    calculatePermissions,
+    calculateEmailConfig,
+    concatApps,
+    distributeSuccessError,
+    dispatchMessages
+} from './functions';
 import { loaderField } from './constants';
 import { mock } from '../__mock__/schemaLoader';
 
@@ -153,6 +161,130 @@ describe('calculateEmailConfig', () => {
                 }
             });
             done();
+        });
+    });
+});
+
+describe('concatApps', () => {
+    it('should concat no app', () => {
+        const apps = concatApps();
+        expect(apps).toBe('');
+    });
+
+    it('should concat one app', () => {
+        const apps = concatApps([ 'one' ]);
+        expect(apps).toBe('one ');
+    });
+
+    it('should concat two apps', () => {
+        const apps = concatApps([ 'one', 'two' ]);
+        expect(apps).toBe('one and two ');
+    });
+
+    it('should concat multiple apps', () => {
+        const apps = concatApps([ 'one', 'two', 'three' ]);
+        expect(apps).toBe('one, two and three ');
+    });
+});
+
+describe('distributeSuccessError', () => {
+    const promiseSuccess = { promise: Promise.resolve(3) };
+    let promiseError;
+    try {
+        promiseError = { promise: new Promise((resolve, reject) => setTimeout(reject, 100, 'foo')) };
+    } catch (e) {
+        (() => {})();
+    }
+
+    it('should not fail with empty', async () => {
+        const { success, error } = await distributeSuccessError();
+        expect(success.length).toBe(0);
+        expect(error.length).toBe(0);
+    });
+
+    it('should not fail with false', async () => {
+        const { success, error } = await distributeSuccessError([ false ]);
+        expect(success.length).toBe(0);
+        expect(error.length).toBe(1);
+    });
+
+    it('should have one success and error', async () => {
+        const { success, error } = await distributeSuccessError([ promiseSuccess, promiseError ]);
+        expect(success.length).toBe(1);
+        expect(error.length).toBe(1);
+    });
+
+    it('should have 2 successes and no error', async () => {
+        const { success, error } = await distributeSuccessError([ promiseSuccess, promiseSuccess ]);
+        expect(success.length).toBe(2);
+        expect(error.length).toBe(0);
+    });
+
+    it('should have 2 errors and no success', async () => {
+        const { success, error } = await distributeSuccessError([ promiseError, promiseError ]);
+        expect(success.length).toBe(0);
+        expect(error.length).toBe(2);
+    });
+});
+
+describe('dispatchMessages', () => {
+    it('should not fail with no messages', () => {
+        const dispatch = jest.fn();
+        dispatchMessages();
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should not fail with no messages', () => {
+        const dispatch = jest.fn();
+        dispatchMessages(dispatch);
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('should dispatch one success', () => {
+        const dispatch = jest.fn();
+        dispatchMessages(dispatch, [ 'some', 'message', 'multiple' ]);
+        expect(dispatch).toHaveBeenCalled();
+        expect(dispatch.mock.calls[0][0]).toMatchObject({
+            payload: {
+                dismissable: false,
+                title: 'Preferences successfully saved',
+                variant: 'success'
+            }
+        });
+    });
+
+    it('should dispatch one danger', () => {
+        const dispatch = jest.fn();
+        dispatchMessages(dispatch, [], [ 'some', 'message', 'multiple' ]);
+        expect(dispatch).toHaveBeenCalled();
+        expect(dispatch.mock.calls[0][0]).toMatchObject({
+            payload: {
+                dismissable: false,
+                title: 'Preferences unsuccessfully saved',
+                variant: 'danger'
+            }
+        });
+    });
+
+    it('should dispatch one danger and one error', () => {
+        const dispatch = jest.fn();
+        dispatchMessages(dispatch, [ 'some', 'message', 'multiple' ], [ 'some', 'message', 'multiple' ]);
+        expect(dispatch).toHaveBeenCalled();
+        expect(dispatch.mock.calls[0][0]).toMatchObject({
+            payload: {
+                dismissable: false,
+                title: 'Preferences successfully saved',
+                description: `User's configuration email for some, message and multiple  were successfully saved.`,
+                variant: 'success'
+            }
+        });
+        expect(dispatch.mock.calls[1][0]).toMatchObject({
+            payload: {
+                dismissable: false,
+                title: 'Preferences unsuccessfully saved',
+                description: `User's configuration email for some, message and multiple  were unsuccessfully saved.`,
+                variant: 'danger'
+            }
         });
     });
 });

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,18 +1,28 @@
 import { getApplicationSchema, saveValues as save } from './api';
 import { ACTION_TYPES } from './constants';
+import config from './config.json';
 
 export const getEmailSchema = ({ application, apiVersion, resourceType = 'email-preference', schema, url }) => ({
     type: ACTION_TYPES.GET_EMAIL_SCHEMA,
     payload: schema || getApplicationSchema(application, apiVersion, resourceType, url),
     meta: {
-        appName: application
+        appName: application,
+        notifications: {
+            rejected: {
+                variant: 'danger',
+                title: 'Request for user user\'s configuration failed',
+                description: `User's configuration email for ${config['email-preference']?.[application]?.title} application does not exist.`
+            }
+        }
     }
 });
 
-export const saveEmailValues = ({ application, values, apiVersion, resourceType = 'email-preference', url, title }) => ({
+export const saveEmailValues = ({ application, values, apiVersion, resourceType = 'email-preference', url }) => ({
     type: ACTION_TYPES.SAVE_EMAIL_SCHEMA,
-    payload: save(application, values, apiVersion, resourceType, url).then(data => ({ ...data, application, title })),
+    payload: save(application, values, apiVersion, resourceType, url),
     meta: {
-        appName: application
+        appName: application,
+        title: config['email-preference']?.[application]?.title,
+        noError: true
     }
 });

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,34 +1,18 @@
 import { getApplicationSchema, saveValues as save } from './api';
 import { ACTION_TYPES } from './constants';
-import config from './config.json';
 
 export const getEmailSchema = ({ application, apiVersion, resourceType = 'email-preference', schema, url }) => ({
     type: ACTION_TYPES.GET_EMAIL_SCHEMA,
     payload: schema || getApplicationSchema(application, apiVersion, resourceType, url),
     meta: {
-        appName: application,
-        notifications: {
-            rejected: {
-                variant: 'danger',
-                title: 'Request for user user\'s configuration failed',
-                description: `User's configuration email for ${config['email-preference']?.[application]?.title} application does not exist.`
-            }
-        }
+        appName: application
     }
 });
 
-export const saveEmailValues = ({ application, values, apiVersion, resourceType = 'email-preference', url }) => ({
+export const saveEmailValues = ({ application, values, apiVersion, resourceType = 'email-preference', url, title }) => ({
     type: ACTION_TYPES.SAVE_EMAIL_SCHEMA,
-    payload: save(application, values, apiVersion, resourceType, url),
+    payload: save(application, values, apiVersion, resourceType, url).then(data => ({ ...data, application, title })),
     meta: {
-        notifications: {
-            fulfilled: {
-                variant: 'success',
-                title: 'User\'s configuration for email saved',
-                // eslint-disable-next-line max-len
-                description: `User's configuration email for ${config['email-preference']?.[application]?.title} application were replaced with new values.`
-            }
-        },
         appName: application
     }
 });

--- a/src/api.js
+++ b/src/api.js
@@ -17,6 +17,6 @@ export const getApplicationSchema = (application, apiVersion = 'v1', resourceTyp
     instance.get(`/api/${application}/${apiVersion}${url || `/user-config/${resourceType}`}`)
 );
 
-export const saveValues = async (application, values, apiVersion = 'v1', resourceType = '', url) => {
-    instance.post(`/api/${application}/${apiVersion}${url || `/user-config/${resourceType}`}`, values);
-};
+export const saveValues = async (application, values, apiVersion = 'v1', resourceType = '', url) => (
+    instance.post(`/api/${application}/${apiVersion}${url || `/user-config/${resourceType}`}`, values)
+);

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,18 @@
 import instance from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
 export { instance };
 
+instance.interceptors.response.use((response) => {
+    if (response?.config?.data) {
+        try {
+            return JSON.parse(response.config.data);
+        } catch (_e) {
+            return response.config.data;
+        }
+    }
+
+    return response;
+});
+
 export const getApplicationSchema = (application, apiVersion = 'v1', resourceType = '', url) => (
     instance.get(`/api/${application}/${apiVersion}${url || `/user-config/${resourceType}`}`)
 );

--- a/src/api.js
+++ b/src/api.js
@@ -18,9 +18,5 @@ export const getApplicationSchema = (application, apiVersion = 'v1', resourceTyp
 );
 
 export const saveValues = async (application, values, apiVersion = 'v1', resourceType = '', url) => {
-    try {
-        return await instance.post(`/api/${application}/${apiVersion}${url || `/user-config/${resourceType}`}`, values);
-    } catch {
-        return undefined;
-    }
+    instance.post(`/api/${application}/${apiVersion}${url || `/user-config/${resourceType}`}`, values);
 };


### PR DESCRIPTION
We should show only one message when sabing data, so we gotta combine multiple success messages together. Same for errors, if there are any.

If there are only success messages show single success message, if there are only errors show single error message, if there are some errors and some successes show 2 messages with list of apps (which failed and which succeeded).

![Screenshot from 2020-04-15 14-00-55](https://user-images.githubusercontent.com/3439771/79349752-ec70d300-7f36-11ea-8142-b92c54caa243.png)

![Screenshot from 2020-04-15 22-33-34](https://user-images.githubusercontent.com/3439771/79388838-59538f80-7f6e-11ea-9b8f-ae202cc328f8.png)



![Screenshot from 2020-04-15 15-49-15](https://user-images.githubusercontent.com/3439771/79349758-eda20000-7f36-11ea-81c5-845dc324f906.png)


#### TODO
* [x] Add tests
* [x] Add pictures