### PR TITLE
Enable custom apiName when fetching DDF schema as well as apiVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ This application is for forms for users to change their preferences. If you want
 
 We rely heavily on library called [Data driven forms](https://data-driven-forms.org/), where we use schema to render components in form. Please go to their documentation if you want to enable new user preferences for your application.
 
-## Expected pahts
-
-In order to properly deliver DDF schema please expose the schema on URL `/api/${appName}/v1/user-config/${prefType}` where appName and prefType comes from `config.json`.
-
 ## Custom components
 
 We have designed a few custom components to be used when working with data driven forms to properly show some information on screen.
@@ -41,6 +37,29 @@ The list of all methods can be found [insights-chrome#permissions](https://githu
               ]
           }
         },
+    }
+}
+```
+
+## Application config
+
+To enable your form parts in user preferences we need at least the application name and its title.
+
+By default this application will try to fetch DDF schema on `/api/${appName}/v1/user-config/${prefType}` where `appName` is ket from `config.json` and `prefType` is defined by each preference. If however you want to change the URL where you serve this schema you are free to do so by setting these fields in your app config.
+
+* `apiName` - this will serve as `appName` when fetching DDF schema `/api/${apiName}/${apiVersion}/user-config/${prefType}`
+* `url` - this will completely change how URL is structured `api/${appName}/v1/${url}`
+* `apiVersion` - this will change version of your API so the URL will look like `/api/${appName}/${apiVersion}/user-config/${prefType}`
+
+And of course you can combine these values together so if your schema is being served on `/api/example/v2/some-custom/url/with/nested/parts` your config should look like (no need to match object key with apiName)
+
+```JSON
+{
+    "example-app": {
+        "title": "Example app",
+        "url": "/some-custom/url/with/nested/parts",
+        "apiName": "example",
+        "apiVersion": "v2"
     }
 }
 ```

--- a/src/PresentationalComponents/Email/Email.js
+++ b/src/PresentationalComponents/Email/Email.js
@@ -50,9 +50,9 @@ const Email = () => {
     const saveValues = async ({ unsubscribe, ...values }) => {
         const promises = Object.entries(emailConfig)
         .filter(([ , { isVisible }]) => isVisible === true)
-        .map(([ application, { localFile, schema, url }]) => {
+        .map(([ application, { localFile, schema, url, apiName }]) => {
             if (!localFile && !schema && store?.[application]?.schema && Object.keys(store?.[application]?.schema).length > 0) {
-                const action = saveEmailValues({ application, values, url });
+                const action = saveEmailValues({ application, values, url, apiName });
                 dispatch(action);
 
                 return {

--- a/src/Utilities/functions.js
+++ b/src/Utilities/functions.js
@@ -14,7 +14,7 @@ export const calculatePermissions = (permissions) => Promise.all(
 export const calculateEmailConfig = (
     { 'email-preference': config } = { 'email-preference': {}},
     dispatch = () => {}
-) => Object.entries(config).map(([ key, { permissions, url, localFile, ...rest }]) => {
+) => Object.entries(config).map(([ key, { permissions, url, apiName, apiVersion, localFile, ...rest }]) => {
     const isVisible = permissions ? calculatePermissions(permissions) : true;
     (async () => {
         const schemaVisible = await Promise.resolve(isVisible);
@@ -23,7 +23,7 @@ export const calculateEmailConfig = (
                 const newMapper = (await import(`../${localFile}`)).default;
                 dispatch(getEmailSchema({ schema: newMapper, application: key }));
             } else {
-                dispatch(getEmailSchema({ application: key, url }));
+                dispatch(getEmailSchema({ application: key, url, apiName, apiVersion }));
             }
         }
     })();
@@ -33,6 +33,8 @@ export const calculateEmailConfig = (
             localFile,
             isVisible,
             url,
+            apiName,
+            apiVersion,
             ...rest
         }
     };

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,9 +2,9 @@ import { getApplicationSchema, saveValues as save } from './api';
 import { ACTION_TYPES } from './constants';
 import config from './config.json';
 
-export const getEmailSchema = ({ application, apiVersion, resourceType = 'email-preference', schema, url }) => ({
+export const getEmailSchema = ({ application, apiVersion, resourceType = 'email-preference', schema, url, apiName }) => ({
     type: ACTION_TYPES.GET_EMAIL_SCHEMA,
-    payload: schema || getApplicationSchema(application, apiVersion, resourceType, url),
+    payload: schema || getApplicationSchema(apiName || application, apiVersion, resourceType, url),
     meta: {
         appName: application,
         notifications: {
@@ -17,9 +17,9 @@ export const getEmailSchema = ({ application, apiVersion, resourceType = 'email-
     }
 });
 
-export const saveEmailValues = ({ application, values, apiVersion, resourceType = 'email-preference', url }) => ({
+export const saveEmailValues = ({ application, values, apiVersion, resourceType = 'email-preference', url, apiName }) => ({
     type: ACTION_TYPES.SAVE_EMAIL_SCHEMA,
-    payload: save(application, values, apiVersion, resourceType, url),
+    payload: save(apiName || application, values, apiVersion, resourceType, url),
     meta: {
         appName: application,
         title: config['email-preference']?.[application]?.title,

--- a/src/config.json
+++ b/src/config.json
@@ -1,8 +1,9 @@
 {
     "email-preference": {
-        "insights": {
-            "title": "Insights",
-            "url": "/user-preferences/"
+        "advisor": {
+            "title": "Advisor",
+            "url": "/user-preferences/",
+            "apiName": "insights"
         },
         "policies": {
             "title": "Policies",


### PR DESCRIPTION
* Allow custom apiName so apps can define their URL partials when fetching DDF schema
* Allow changing apiVersion, it should have been enabled before, but got slipped trough