### PR TITLE
Use babel proposals on usage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
     "presets": [
-        "@babel/env",
+        ["@babel/env", { "useBuiltIns": "usage", "corejs": { "version": 3, "proposals": true } }],
         "@babel/react",
         "@babel/flow"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5277,6 +5277,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+    },
     "core-js-compat": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@redhat-cloud-services/frontend-components-notifications": "^1.0.1",
     "@redhat-cloud-services/frontend-components-utilities": "1.0.0",
     "classnames": "^2.2.6",
+    "core-js": "^3.6.5",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-redux": "^7.2.0",


### PR DESCRIPTION
Since `Promise.allSettled` is not supported by all major browsers [Promise/allSettled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) we should include polyfill to make it work on older browsers (mainly on FF 68 esr).

I can include just the one polyfill as stated in https://github.com/babel/babel/issues/10883#issuecomment-566725743 not to include all polyfills for older browsers.