### PR TITLE
Fix spacing in Email preferences

### DIFF
--- a/src/PresentationalComponents/Email/Email.js
+++ b/src/PresentationalComponents/Email/Email.js
@@ -93,7 +93,7 @@ const Email = () => {
                 <Stack gutter="md">
                     <StackItem>
                         <Card className="pref-email__info">
-                            <CardHeader className="pref-email__info-head">
+                            <CardHeader>
                                 <TextContent>
                                     <Text component={ TextVariants.h2 }>Your information</Text>
                                 </TextContent>
@@ -103,16 +103,19 @@ const Email = () => {
                                     <DataListItem>
                                         <DataListItemRow>
                                             <DataListItemCells dataListCells={ [
-                                                <DataListCell isFilled={ false } className="pref-c-title pref-u-bold" key="email-title">
+                                                <DataListCell
+                                                    isFilled={ false }
+                                                    className="pref-c-title pref-u-bold pref-u-condensed"
+                                                    key="email-title">
                                                     Email address
                                                 </DataListCell>,
                                                 <DataListCell
                                                     isFilled
                                                     key="email-value"
-                                                    className="pref-email__info-user-email"
+                                                    className="pref-email__info-user-email pref-u-condensed"
                                                 >
                                                     { isLoaded ? (
-                                                        <Fragment>
+                                                        <Fragment className="pref-u-condensed">
                                                             <span>{currentUser.email}</span>
                                                             <a
                                                                 rel="noopener noreferrer"
@@ -134,7 +137,7 @@ const Email = () => {
                     </StackItem>
                     <StackItem>
                         <Card>
-                            <CardHeader className="pref-email__info-head pref-email__subs-info">
+                            <CardHeader className="pref-email__info-head">
                                 <TextContent>
                                     <Text component={ TextVariants.h2 }>Email subscriptions</Text>
                                 </TextContent>

--- a/src/PresentationalComponents/Email/email.scss
+++ b/src/PresentationalComponents/Email/email.scss
@@ -14,8 +14,6 @@
             // min and max width, because data lists
             min-width: 155px;
             max-width: 155px;
-
-            @include rem('padding-top', 22px);
         }
         .pf-c-data-list__item:last-of-type { border: 0; }
 
@@ -49,8 +47,17 @@
 
     .pref-u-bold { font-weight: var(--pf-global--FontWeight--bold); }
 
+    .pref-u-condensed {
+        padding-top: 8px !important;
+        padding-bottom: 0px;
+    }
+
     .pref-email__form-button {
         margin-right: 16px;
+    }
+
+    .pref-email__info-head {
+        display: block;
     }
 }
 
@@ -90,6 +97,11 @@
             .pf-c-data-list__cell:last-of-type {
                 padding-top: var(--pf-global--spacer--lg);
             }
+        }
+
+        .pref-u-condensed {
+            padding-top: 0px !important;
+            padding-bottom: 0px;
         }
     }
 }

--- a/src/PresentationalComponents/Email/email.scss
+++ b/src/PresentationalComponents/Email/email.scss
@@ -47,8 +47,8 @@
 
     .pref-u-bold { font-weight: var(--pf-global--FontWeight--bold); }
 
-    .pref-u-condensed {
-        padding-top: 8px !important;
+    div.pref-u-condensed {
+        padding-top: var(--pf-global--spacer--sm);
         padding-bottom: 0px;
     }
 
@@ -58,6 +58,7 @@
 
     .pref-email__info-head {
         display: block;
+        padding-bottom: 0px;
     }
 }
 
@@ -98,10 +99,15 @@
                 padding-top: var(--pf-global--spacer--lg);
             }
         }
-
-        .pref-u-condensed {
-            padding-top: 0px !important;
-            padding-bottom: 0px;
+        
+        ul.pf-c-data-list {
+            .pf-c-data-list__item {
+                div.pf-c-data-list__cell.pref-u-condensed {
+                    padding-top: 0px;
+                    padding-bottom: 0px;
+                }
+            }
         }
     }
 }
+


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/RHCLOUD-6200

**Desktop:**
Spacing made 24px total between "your information" and "email address"

![001](https://user-images.githubusercontent.com/50696716/88195887-d4e56c80-cc40-11ea-950b-e4996d6fc8d7.png)

**Mobile:**
Spacing made 16px between "your information" and "email address"
Spacing made 0px, between "Email address" and the email

![002](https://user-images.githubusercontent.com/50696716/88195907-db73e400-cc40-11ea-9327-2b9b8b13f561.png)

Fixed missing display block in email subscriptions header

@karelhala 
@mmenestr