### PR TITLE
Adds missing lib node-sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15515,9 +15515,9 @@
       }
     },
     "sass-loader": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.1.0.tgz",
-      "integrity": "sha512-ZCKAlczLBbFd3aGAhowpYEy69Te3Z68cg8bnHHl6WnSCvnKpbM6pQrz957HWMa8LKVuhnD9uMplmMAHwGQtHeg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.1.1.tgz",
+      "integrity": "sha512-W6gVDXAd5hR/WHsPicvZdjAWHBcEJ44UahgxcIE196fW2ong0ZHMPO1kZuI5q0VlvMQZh32gpv69PLWQm70qrw==",
       "dev": true,
       "requires": {
         "klona": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.27",
     "prop-types": "^15.7.2",
+    "sass-loader": "^10.1.1",
     "stylelint": "^13.2.1",
     "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-scss": "^3.14.2",


### PR DESCRIPTION
 `start` was failing because of this missing lib

Fix: "Module not found: Error: Cannot resolve module 'sass-loader'" when calling `start`

Note: The error is gone, but the following warning appears: `WARNING in chunk pfVendor [mini-css-extract-plugin]....`.