### PR TITLE
Remove email section from notifications

### DIFF
--- a/src/PresentationalComponents/Notification/Notification.js
+++ b/src/PresentationalComponents/Notification/Notification.js
@@ -1,4 +1,3 @@
-import YourInformation from '../shared/YourInformation';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import './notification.scss';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
@@ -114,9 +113,6 @@ const Notification = () => {
       </PageHeader>
       <Main className="pref-notification">
         <Stack hasGutter>
-          <StackItem>
-            <YourInformation />
-          </StackItem>
           <StackItem>
             <Card ouiaId="user-pref-notification-subscriptions-card">
               <CardHeader className="pf-u-pb-0">


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHCLOUD-13935

Removed displaying email in the Notifications
![001](https://user-images.githubusercontent.com/50696716/123515685-af56b380-d698-11eb-8a7d-21a095eb0e40.png)
![002](https://user-images.githubusercontent.com/50696716/123515690-b1b90d80-d698-11eb-9f8b-5715d8902671.png)

@mmenestr