### PR TITLE
Frontend Migration 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "moduleNameMapper": {
       "\\.(css|scss)$": "identity-obj-proxy"
     },
-    "testURL": "http://localhost:5000/"
+    "testURL": "http://localhost:5000/",
+    "test": "TZ=UTC jest --verbose --no-cache"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",


### PR DESCRIPTION
For the frontend migration process, we need to disable the jest cache.

This completes the steps for RHCLOUD-22780

Signed-off-by: Stephen Adams <stephen.adams@redhat.com>
