### PR TITLE
RHCLOUD-24572 : show infoIcon&msg only if there is a message to be shown

### DIFF
--- a/src/PresentationalComponents/Notifications/__snapshots__/Notifications.test.js.snap
+++ b/src/PresentationalComponents/Notifications/__snapshots__/Notifications.test.js.snap
@@ -363,24 +363,6 @@ exports[`Notifications tests should render correctly 1`] = `
                         >
                           Description.
                         </span>
-                        <span
-                          class="pref-c-checkbox-info"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                            />
-                          </svg>
-                           
-                        </span>
                       </div>
                     </span>
                   </div>

--- a/src/SmartComponents/FormComponents/DescriptiveCheckbox.js
+++ b/src/SmartComponents/FormComponents/DescriptiveCheckbox.js
@@ -64,7 +64,7 @@ const DescriptiveCheckbox = (props) => {
               <span className="pref-c-checkbox-description">{description}</span>
             </>
           )}
-          {!checked && checkedWarning && (
+          {!checked && infoMessage && (
             <span className="pref-c-checkbox-info">
               <InfoCircleIcon /> {infoMessage}
             </span>


### PR DESCRIPTION
Show infoMessage and Icon only when there is an infoMessage(forced email), currently there are no forced emails on any application, so this should not be seen anywhere at the moment.