### PR TITLE
Fix infinite loading

### DIFF
--- a/src/PresentationalComponents/Notifications/utils.js
+++ b/src/PresentationalComponents/Notifications/utils.js
@@ -42,17 +42,18 @@ export const prepareFields = (notifPref, emailPref, emailConfig) =>
             let selectAllActive = true;
             const fields = [
               ...Object.entries(emailPref).reduce(
-                (acc, emailSection) => [
+                (acc, [emailSectionKey, emailSectionValue]) => [
                   ...acc,
-                  ...(emailSection[0] === appKey &&
-                  emailConfig[emailSection[0]]?.bundle === bundleKey
+                  ...(emailSectionKey === appKey &&
+                  emailConfig[emailSectionKey]?.bundle === bundleKey &&
+                  emailSectionValue.schema.length !== 0
                     ? [
                         {
                           label: 'Reports',
                           name: 'email-reports',
                           component: INPUT_GROUP,
                           level: 1,
-                          fields: emailSection[1].schema[0]?.fields?.map(
+                          fields: emailSectionValue.schema[0]?.fields?.map(
                             (field) => {
                               selectAllActive =
                                 selectAllActive && field.initialValue;

--- a/src/Utilities/functions.js
+++ b/src/Utilities/functions.js
@@ -63,6 +63,13 @@ export const calculateEmailConfig = (
                 getEmailSchema({ application: key, url, apiName, apiVersion })
               );
             }
+          } else {
+            dispatch(
+              getEmailSchema({
+                schema: Promise.resolve(),
+                application: key,
+              })
+            );
           }
         })();
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When customer doesn't have anough rights to view advisor UI the advisor email preferences never loads and blocks the loading of our application. This PR fixes it by passing empty schema in this case and also when parsing schemas ignore empty schemas so we won't end up in DDF error.

[RHCLOUD-36501](https://issues.redhat.com/browse/RHCLOUD-36501)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2024-11-27 at 13 12 53](https://github.com/user-attachments/assets/7b186dcc-50cf-46e6-ba11-eb63a791d5f6)


#### After:

![Screenshot 2024-11-27 at 13 11 20](https://github.com/user-attachments/assets/fd2ca46b-3be6-43bd-9620-00f857a51b1a)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
