### PR TITLE
RHCLOUD-36074 add tooltip to disabled button

### DIFF
--- a/src/PresentationalComponents/Notifications/Notifications.test.js
+++ b/src/PresentationalComponents/Notifications/Notifications.test.js
@@ -13,8 +13,6 @@ import {
   act,
   fireEvent,
   getAllByRole,
-  getByLabelText,
-  getByRole,
   getByText,
   queryByText,
   render,

--- a/src/PresentationalComponents/Notifications/TabsMenu.js
+++ b/src/PresentationalComponents/Notifications/TabsMenu.js
@@ -17,7 +17,6 @@ import {
   MenuSearch,
   MenuSearchInput,
   SearchInput,
-  TextInput,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { useLocation, useNavigate } from 'react-router-dom';

--- a/src/PresentationalComponents/Notifications/TabsMenu.test.js
+++ b/src/PresentationalComponents/Notifications/TabsMenu.test.js
@@ -1,12 +1,6 @@
 import React from 'react';
 import { Form, RendererContext } from '@data-driven-forms/react-form-renderer';
-import {
-  fireEvent,
-  getByRole,
-  getByText,
-  render,
-  screen,
-} from '@testing-library/react';
+import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import TabsMenu from './TabsMenu';
 
 const mockedNavigate = jest.fn();

--- a/src/SmartComponents/FormComponents/BulkSelectButton.js
+++ b/src/SmartComponents/FormComponents/BulkSelectButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button, Tooltip } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
@@ -15,14 +15,31 @@ const BulkSelectButton = (props) => {
 
   const [searchParams] = useSearchParams();
 
-  return (
+  const showTooltipAndDisableButton =
+    searchParams.get('bundle') === 'openshift' &&
+    searchParams.get('app') === 'cluster-manager';
+
+  return showTooltipAndDisableButton ? (
+    <Tooltip content="You can not unsubscribe from these notifications. Please contact your org admin for more information.">
+      <Button
+        className="pref-c-bulk-select-button"
+        variant="secondary"
+        isDisabled={
+          searchParams.get('bundle') === 'openshift' &&
+          searchParams.get('app') === 'cluster-manager'
+        }
+        {...input}
+        id={`bulk-select-${section}`}
+        onClick={() => onClick?.(formOptions, input)}
+      >
+        {input.value ? 'Select' : 'Deselect'} all
+      </Button>
+    </Tooltip>
+  ) : (
     <Button
       className="pref-c-bulk-select-button"
       variant="secondary"
-      isDisabled={
-        searchParams.get('bundle') === 'openshift' &&
-        searchParams.get('app') === 'cluster-manager'
-      }
+      isDisabled={showTooltipAndDisableButton}
       {...input}
       id={`bulk-select-${section}`}
       onClick={() => onClick?.(formOptions, input)}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Add tooltip to OS cluster-manager disabled button.

[RHCLOUD-36074](https://issues.redhat.com/browse/RHCLOUD-36074)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
