### PR TITLE
fix: prevent double-wrapping of emailSubscriptionTypes in prod

### DIFF
--- a/src/PresentationalComponents/Notifications/Notifications.js
+++ b/src/PresentationalComponents/Notifications/Notifications.js
@@ -233,14 +233,7 @@ const Notifications = () => {
         {}
       ),
     };
-    const promises = [
-      dispatch(saveNotificationValues(notificationValues)).catch((err) => {
-        console.error('Notifications save failed:', err);
-        console.error('Error response:', err.response?.data);
-        console.error('Error status:', err.response?.status);
-        throw err;
-      }),
-    ];
+    const promises = [dispatch(saveNotificationValues(notificationValues))];
     const submitEmail = formApi.getState().dirtyFields['is_subscribed'];
     // temporary submitting of RHEL Advisor email pref.
     if (submitEmail) {
@@ -251,12 +244,7 @@ const Notifications = () => {
         url,
         apiName,
       });
-      promises.push(
-        dispatch(action).catch((err) => {
-          console.error('Email preferences save failed:', err);
-          throw err;
-        })
-      );
+      promises.push(dispatch(action));
     }
     Promise.all(promises)
       .then(() => {
@@ -268,23 +256,11 @@ const Notifications = () => {
           title: 'Notification preferences successfully saved',
         });
       })
-      .catch((error) => {
-        console.error('Failed to save notification preferences:', error);
-        const errorMessage =
-          error?.response?.data?.message ||
-          error?.response?.data?.error ||
-          error?.message ||
-          'An unknown error occurred';
-        const errorDetails = error?.response?.data
-          ? JSON.stringify(error.response.data)
-          : '';
+      .catch(() => {
         addNotification({
           dismissable: true,
           variant: 'danger',
           title: 'Notification preferences unsuccessfully saved',
-          description: `${errorMessage}${
-            errorDetails ? ` - Details: ${errorDetails}` : ''
-          }`,
         });
       });
   };

--- a/src/PresentationalComponents/Notifications/Notifications.js
+++ b/src/PresentationalComponents/Notifications/Notifications.js
@@ -233,7 +233,14 @@ const Notifications = () => {
         {}
       ),
     };
-    const promises = [dispatch(saveNotificationValues(notificationValues))];
+    const promises = [
+      dispatch(saveNotificationValues(notificationValues)).catch((err) => {
+        console.error('Notifications save failed:', err);
+        console.error('Error response:', err.response?.data);
+        console.error('Error status:', err.response?.status);
+        throw err;
+      }),
+    ];
     const submitEmail = formApi.getState().dirtyFields['is_subscribed'];
     // temporary submitting of RHEL Advisor email pref.
     if (submitEmail) {
@@ -244,7 +251,12 @@ const Notifications = () => {
         url,
         apiName,
       });
-      promises.push(dispatch(action));
+      promises.push(
+        dispatch(action).catch((err) => {
+          console.error('Email preferences save failed:', err);
+          throw err;
+        })
+      );
     }
     Promise.all(promises)
       .then(() => {
@@ -256,11 +268,23 @@ const Notifications = () => {
           title: 'Notification preferences successfully saved',
         });
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error('Failed to save notification preferences:', error);
+        const errorMessage =
+          error?.response?.data?.message ||
+          error?.response?.data?.error ||
+          error?.message ||
+          'An unknown error occurred';
+        const errorDetails = error?.response?.data
+          ? JSON.stringify(error.response.data)
+          : '';
         addNotification({
           dismissable: true,
           variant: 'danger',
           title: 'Notification preferences unsuccessfully saved',
+          description: `${errorMessage}${
+            errorDetails ? ` - Details: ${errorDetails}` : ''
+          }`,
         });
       });
   };

--- a/src/SmartComponents/FormComponents/severityUtils.test.ts
+++ b/src/SmartComponents/FormComponents/severityUtils.test.ts
@@ -199,4 +199,41 @@ describe('stripSeverityGridUiFromEventTypes', () => {
       (stripped.evt as { subscriptionTypes: unknown }).subscriptionTypes
     ).toBeDefined();
   });
+
+  it('does not double-wrap emailSubscriptionTypes', () => {
+    // When severity flag is OFF, form sends data already wrapped in emailSubscriptionTypes
+    const alreadyWrapped = {
+      emailSubscriptionTypes: {
+        INSTANT: true,
+        DAILY: false,
+      },
+    };
+    const stripped = stripSeverityGridUiFromEventTypes({ evt: alreadyWrapped });
+    // Should not add another layer of wrapping
+    expect(stripped.evt).toEqual({
+      emailSubscriptionTypes: {
+        INSTANT: true,
+        DAILY: false,
+      },
+    });
+    // Verify it's not double-wrapped
+    expect(
+      (stripped.evt as Record<string, unknown>).emailSubscriptionTypes
+    ).not.toHaveProperty('emailSubscriptionTypes');
+  });
+
+  it('wraps plain objects in emailSubscriptionTypes', () => {
+    // When data comes as plain object (no wrapper), wrap it
+    const plainObject = {
+      INSTANT: true,
+      DAILY: false,
+    };
+    const stripped = stripSeverityGridUiFromEventTypes({ evt: plainObject });
+    expect(stripped.evt).toEqual({
+      emailSubscriptionTypes: {
+        INSTANT: true,
+        DAILY: false,
+      },
+    });
+  });
 });

--- a/src/SmartComponents/FormComponents/severityUtils.ts
+++ b/src/SmartComponents/FormComponents/severityUtils.ts
@@ -266,9 +266,19 @@ export const stripSeverityGridUiFromEventTypes = (
       continue;
     }
     // Handle simple object structure {INSTANT: bool, DAILY: bool} from NotificationEventCard
-    // Wrap in emailSubscriptionTypes for backend
+    // Wrap in emailSubscriptionTypes for backend (if not already wrapped)
+    // TODO: Once severity flag is fully rolled out and old INPUT_GROUP code removed,
+    // consider moving this wrapping responsibility into NotificationEventCard itself
+    // to simplify this function's scope to just severity grid data.
     if (typeof v === 'object' && v !== null && !Array.isArray(v)) {
-      out[k] = { emailSubscriptionTypes: v as Record<string, boolean> };
+      // Check if already wrapped in emailSubscriptionTypes to avoid double-wrapping.
+      // Old INPUT_GROUP layout has wrapping already done via backend schema field names.
+      // NotificationEventCard sends unwrapped plain objects.
+      if ('emailSubscriptionTypes' in v) {
+        out[k] = v as StrippedEventPreference;
+      } else {
+        out[k] = { emailSubscriptionTypes: v as Record<string, boolean> };
+      }
       continue;
     }
     out[k] = v as StrippedEventPreference;


### PR DESCRIPTION
## Summary
Fixes 400 Bad Request error when saving notification preferences in production where the `platform.notifications.severity` feature flag is disabled.

## Problem
Users in production cannot save notification preferences. When they click Save, they receive an error notification and the browser console shows:
```
AxiosError: Request failed with status code 400
```

## Root Cause
When the severity flag is **OFF** (current production state), the old `INPUT_GROUP` layout uses backend schema field names like:
```
bundles[console].applications[rbac].eventTypes[request-access].emailSubscriptionTypes[INSTANT]
```

Data Driven Forms automatically creates nested structure from these field names:
```json
{"emailSubscriptionTypes": {"INSTANT": true}}
```

The `stripSeverityGridUiFromEventTypes` function was then wrapping this **again**, creating invalid double-nested structure:
```json
{"emailSubscriptionTypes": {"emailSubscriptionTypes": {"INSTANT": true}}}
```

The backend rejects this with HTTP 400.

## Solution
Added a check in `stripSeverityGridUiFromEventTypes` to detect if data is already wrapped in `emailSubscriptionTypes` before adding another wrapper. This safely handles both:
- **Old layout** (severity flag OFF): Data already wrapped via backend schema field names → pass through as-is
- **New layout** (severity flag ON): Data unwrapped from NotificationEventCard → wrap it for backend

## Changes
- `severityUtils.ts`: Added double-wrapping prevention logic + TODO for future cleanup
- `severityUtils.test.ts`: Added regression tests for both wrapping scenarios
- `Notifications.js`: Enhanced error logging to show backend error details

## Testing
- ✅ All existing tests pass
- ✅ New regression tests added and passing
- ✅ Code handles both feature flag states during transition

## Future Cleanup
Once `platform.notifications.severity` is fully rolled out to all environments, the old INPUT_GROUP code path can be removed and this logic simplified. See TODO comment in `severityUtils.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)