### PR TITLE
feat(severity): show severity always

### DIFF
--- a/src/PresentationalComponents/Notifications/Notifications.js
+++ b/src/PresentationalComponents/Notifications/Notifications.js
@@ -11,7 +11,6 @@ import {
   SeverityMinorIcon,
   SeverityModerateIcon,
   SeverityNoneIcon,
-  SeverityUndefinedIcon,
 } from '@patternfly/react-icons';
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
 import { useNotifications } from '@redhat-cloud-services/frontend-components-notifications/hooks';
@@ -84,12 +83,6 @@ const severityTerms = [
     icon: SeverityNoneIcon,
     color: 'var(--pf-t--global--icon--color--severity--none--default)',
     description: 'No security-related impact for this notification',
-  },
-  {
-    label: 'Undefined',
-    icon: SeverityUndefinedIcon,
-    color: 'var(--pf-t--global--icon--color--severity--undefined--default)',
-    description: 'Severity may be determined later',
   },
 ];
 

--- a/src/PresentationalComponents/Notifications/Notifications.stories.tsx
+++ b/src/PresentationalComponents/Notifications/Notifications.stories.tsx
@@ -16,13 +16,15 @@ const kesselApiHandlers = [
     const type = url.searchParams.get('type');
     if (type === 'default') {
       return HttpResponse.json({
-        data: [{
-          id: 'default-workspace-123',
-          name: 'Default Workspace',
-          type: 'default',
-          created: '2024-01-01T00:00:00Z',
-          modified: '2024-01-01T00:00:00Z',
-        }],
+        data: [
+          {
+            id: 'default-workspace-123',
+            name: 'Default Workspace',
+            type: 'default',
+            created: '2024-01-01T00:00:00Z',
+            modified: '2024-01-01T00:00:00Z',
+          },
+        ],
         meta: { count: 1 },
       });
     }
@@ -44,7 +46,9 @@ const kesselApiHandlers = [
       'user_preferences_read',
     ];
 
-    const allowed = allowedRelations.includes(relation) ? 'ALLOWED_TRUE' : 'ALLOWED_FALSE';
+    const allowed = allowedRelations.includes(relation)
+      ? 'ALLOWED_TRUE'
+      : 'ALLOWED_FALSE';
 
     return HttpResponse.json({ allowed });
   }),
@@ -119,9 +123,6 @@ export const Default = {
     ).toBeInTheDocument();
     await expect(
       canvas.getByRole('button', { name: /^None$/ })
-    ).toBeInTheDocument();
-    await expect(
-      canvas.getByRole('button', { name: 'Undefined' })
     ).toBeInTheDocument();
   },
 } satisfies StoryObj<typeof meta>;

--- a/src/PresentationalComponents/Notifications/SeverityHelpTerms.test.js
+++ b/src/PresentationalComponents/Notifications/SeverityHelpTerms.test.js
@@ -100,7 +100,7 @@ const renderNotifications = () =>
   );
 
 describe('Severity help terms in Notifications header', () => {
-  it('renders all six severity terms', () => {
+  it('renders all five severity terms', () => {
     renderNotifications();
 
     expect(screen.getByText('Critical')).toBeInTheDocument();
@@ -108,7 +108,7 @@ describe('Severity help terms in Notifications header', () => {
     expect(screen.getByText('Moderate')).toBeInTheDocument();
     expect(screen.getByText('Low')).toBeInTheDocument();
     expect(screen.getByText('None')).toBeInTheDocument();
-    expect(screen.getByText('Undefined')).toBeInTheDocument();
+    expect(screen.queryByText('Undefined')).not.toBeInTheDocument();
   });
 
   it('renders the severity description sentence', () => {
@@ -149,11 +149,6 @@ describe('Severity help terms in Notifications header', () => {
 
     const noneButton = screen.getByRole('button', { name: /^None$/i });
     expect(noneButton).toHaveClass('pref-notifications--severity-term');
-
-    const undefinedButton = screen.getByRole('button', {
-      name: /Undefined/i,
-    });
-    expect(undefinedButton).toHaveClass('pref-notifications--severity-term');
   });
 
   it('opens a popover when a severity term is clicked', async () => {
@@ -226,23 +221,6 @@ describe('Severity help terms in Notifications header', () => {
 
     expect(
       screen.getByText(/No security-related impact for this notification/)
-    ).toBeInTheDocument();
-  });
-
-  it('shows correct description in Undefined popover', async () => {
-    renderNotifications();
-
-    const undefinedButton = screen.getByRole('button', {
-      name: /Undefined/i,
-    });
-    fireEvent.click(undefinedButton);
-
-    await waitFor(() => {
-      expect(screen.getByText('Undefined severity')).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText(/Severity may be determined later/)
     ).toBeInTheDocument();
   });
 

--- a/src/PresentationalComponents/Notifications/utils.js
+++ b/src/PresentationalComponents/Notifications/utils.js
@@ -139,7 +139,7 @@ export const prepareFields = (
                       if (eventType.fields?.[0]?.severities) {
                         const enabledSeverity =
                           eventType.fields[0].severities.find(
-                            (s) => !s.disabled
+                            (s) => !s.disabled && s.name !== 'UNDEFINED'
                           );
                         eventSeverity = enabledSeverity?.name;
                       }

--- a/src/SmartComponents/FormComponents/NotificationEventCard.test.tsx
+++ b/src/SmartComponents/FormComponents/NotificationEventCard.test.tsx
@@ -89,7 +89,7 @@ describe('NotificationEventCard tests', () => {
     expect(screen.getByLabelText('Daily digest email')).toBeInTheDocument();
   });
 
-  it('should not show severity badge when no options are selected', () => {
+  it('should show severity badge even when no options are selected', () => {
     render(
       <Form onSubmit={() => undefined}>
         {(props) => (
@@ -118,7 +118,39 @@ describe('NotificationEventCard tests', () => {
       </Form>
     );
 
-    expect(screen.queryByText('Critical')).not.toBeInTheDocument();
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+  });
+
+  it('should not show severity badge for undefined severity', () => {
+    render(
+      <Form onSubmit={() => undefined}>
+        {(props) => (
+          <RendererContext.Provider
+            value={
+              {
+                formOptions: {
+                  internalRegisterField: () => undefined,
+                  internalUnRegisterField: () => undefined,
+                } as any,
+              } as any
+            }
+          >
+            <NotificationEventCard
+              name="test-event"
+              eventName="POLICY_FAILED"
+              eventLabel="Policy failed"
+              severity="UNDEFINED"
+              subscriptionFields={sampleFields}
+              bundle="rhel"
+              app="compliance"
+              {...(props as any)}
+            />
+          </RendererContext.Provider>
+        )}
+      </Form>
+    );
+
+    expect(screen.queryByText('Undefined')).not.toBeInTheDocument();
   });
 
   it('should show severity badge when at least one option is selected', () => {

--- a/src/SmartComponents/FormComponents/NotificationEventCard.tsx
+++ b/src/SmartComponents/FormComponents/NotificationEventCard.tsx
@@ -166,6 +166,9 @@ const severityDescription: Record<string, string> = {
   UNDEFINED: 'Severity level has not been defined for this event',
 };
 
+const isDisplayableSeverity = (severity?: string): severity is string =>
+  Boolean(severity && severity.toUpperCase() !== 'UNDEFINED');
+
 const NotificationEventCard: React.FC<NotificationEventCardProps> = (props) => {
   const {
     eventName,
@@ -195,12 +198,6 @@ const NotificationEventCard: React.FC<NotificationEventCardProps> = (props) => {
     afterChange?.(formOptions, checked);
   };
 
-  // Check if any option is selected (handle undefined/null value)
-  const hasSelectedOptions =
-    value && typeof value === 'object'
-      ? Object.values(value).some((v) => Boolean(v))
-      : false;
-
   return (
     <Card isCompact style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}>
       <CardHeader>
@@ -220,7 +217,7 @@ const NotificationEventCard: React.FC<NotificationEventCardProps> = (props) => {
             >
               {eventLabel}
             </span>
-            {severity && hasSelectedOptions && (
+            {isDisplayableSeverity(severity) && (
               <Tooltip
                 content={
                   severityDescription[severity.toUpperCase()] ||


### PR DESCRIPTION
[RHCLOUD-47915](https://redhat.atlassian.net/browse/RHCLOUD-47915)
Notification Preferences page: Event type severity is visible only when user subscribed

Show severity always

<img width="1490" height="755" alt="Screenshot 2026-06-09 at 11 53 27 AM" src="https://github.com/user-attachments/assets/3745edc2-fb10-4ba3-a632-0e6ce2133ebb" />


[RHCLOUD-47915]: https://redhat.atlassian.net/browse/RHCLOUD-47915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ