### PR TITLE
fix: use bulk Kessel API and remove window.insights global injection

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,12 +15,8 @@ rules:
     - ignoreDeclarationSort: true
 overrides:
   - files:
-      - 'src/SmartComponents/FormComponents/severityOrder.ts'
-      - 'src/SmartComponents/FormComponents/severityUtils.ts'
-      - 'src/SmartComponents/FormComponents/severityUtils.test.ts'
-      - 'src/SmartComponents/FormComponents/NotificationEventCard.tsx'
-      - 'src/SmartComponents/FormComponents/NotificationEventCard.test.tsx'
-      - 'src/SmartComponents/FormComponents/NotificationEventCard.stories.tsx'
+      - 'src/**/*.ts'
+      - 'src/**/*.tsx'
     parser: '@typescript-eslint/parser'
     plugins:
       - '@typescript-eslint'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,10 @@ const VersionRouter: React.FC = () => {
 
   return hasRbacV2 ? (
     // RBAC v2: Wrap with Kessel providers
-    <AccessCheck.Provider baseUrl={window.location.origin} apiPath="/api/kessel/v1beta2">
+    <AccessCheck.Provider
+      baseUrl={window.location.origin}
+      apiPath="/api/kessel/v1beta2"
+    >
       <KesselRbacAccessProvider>
         <AppInner />
       </KesselRbacAccessProvider>

--- a/src/PresentationalComponents/Notifications/Notifications.js
+++ b/src/PresentationalComponents/Notifications/Notifications.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import omit from 'lodash/omit';
 import { useFlag } from '@unleash/proxy-client-react';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useKesselRbacAccess } from '../../Utilities/kesselRbac';
 import { FormRenderer } from '@data-driven-forms/react-form-renderer';
 import { componentMapper } from '@data-driven-forms/pf4-component-mapper';
 import { Bullseye, Button, Popover, Spinner } from '@patternfly/react-core';
@@ -175,7 +176,9 @@ const Notifications = () => {
     PLATFORM_NOTIFICATIONS_SEVERITY_FLAG
   );
   const isVAEnabled = useFlag('platform.va.environment.enabled');
+  const isV2Org = useFlag('platform.rbac.workspaces');
   const { auth } = useChrome();
+  const { permissions: kesselMappedPermissions } = useKesselRbacAccess();
   const dispatch = useDispatch();
   const { addNotification } = useNotifications();
   const titleRef = useRef(null);
@@ -199,7 +202,12 @@ const Notifications = () => {
   useEffect(() => {
     (async () => {
       await auth.getUser();
-      setEmailConfig(calculateEmailConfig(config, dispatch));
+      setEmailConfig(
+        calculateEmailConfig(config, dispatch, {
+          isV2Org,
+          kesselMappedPermissions,
+        })
+      );
       dispatch(getNotificationsSchema());
     })();
   }, []);
@@ -241,7 +249,13 @@ const Notifications = () => {
     }
     Promise.all(promises)
       .then(() => {
-        submitEmail && setEmailConfig(calculateEmailConfig(config, dispatch));
+        submitEmail &&
+          setEmailConfig(
+            calculateEmailConfig(config, dispatch, {
+              isV2Org,
+              kesselMappedPermissions,
+            })
+          );
         dispatch(getNotificationsSchema());
         addNotification({
           dismissable: true,

--- a/src/PresentationalComponents/shared/FormButtons.stories.tsx
+++ b/src/PresentationalComponents/shared/FormButtons.stories.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
-import { FormRenderer, componentTypes } from '@data-driven-forms/react-form-renderer';
-import { componentMapper, FormTemplate } from '@data-driven-forms/pf4-component-mapper';
+import {
+  FormRenderer,
+  componentTypes,
+} from '@data-driven-forms/react-form-renderer';
+import {
+  FormTemplate,
+  componentMapper,
+} from '@data-driven-forms/pf4-component-mapper';
 import { fn } from 'storybook/test';
 import FormButtons from './FormButtons';
 
@@ -66,7 +72,8 @@ export const NoChanges: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Buttons are hidden when the form is pristine (no changes made). Try typing in the field to see them appear.',
+        story:
+          'Buttons are hidden when the form is pristine (no changes made). Try typing in the field to see them appear.',
       },
     },
   },
@@ -105,7 +112,8 @@ export const WithChanges: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Buttons are enabled when the form has unsaved changes. Modify the text field to see the buttons.',
+        story:
+          'Buttons are enabled when the form has unsaved changes. Modify the text field to see the buttons.',
       },
     },
   },
@@ -155,7 +163,8 @@ export const AfterSubmit: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'After a successful submit, buttons are hidden until new changes are made to the form.',
+        story:
+          'After a successful submit, buttons are hidden until new changes are made to the form.',
       },
     },
   },

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -1,9 +1,11 @@
 import React, { Fragment, Suspense, lazy, useMemo } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import pathnames from './Utilities/pathnames';
-import { InvalidObject } from '@redhat-cloud-services/frontend-components';
+import InvalidObject from '@redhat-cloud-services/frontend-components/InvalidObject';
 
-const Notifications = lazy(() => import('./PresentationalComponents/Notifications/Notifications'));
+const Notifications = lazy(
+  () => import('./PresentationalComponents/Notifications/Notifications')
+);
 
 const routes = [
   {
@@ -28,13 +30,15 @@ const renderRoutes = (routes: RouteType[] = []) =>
 
 export const Routing = () => {
   const renderedRoutes = useMemo(() => renderRoutes(routes), [routes]);
-  return (<Suspense fallback="">
-    <Routes>
-      {renderedRoutes}
-      {/* Catch all unmatched routes */}
-      <Route path="*" element={<Notifications />} />
-    </Routes>
-  </Suspense>
-)}
+  return (
+    <Suspense fallback="">
+      <Routes>
+        {renderedRoutes}
+        {/* Catch all unmatched routes */}
+        <Route path="*" element={<Notifications />} />
+      </Routes>
+    </Suspense>
+  );
+};
 
 export default Routing;

--- a/src/SmartComponents/FormComponents/Loader.stories.tsx
+++ b/src/SmartComponents/FormComponents/Loader.stories.tsx
@@ -57,7 +57,8 @@ export const Medium: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Medium loader skeleton - the default size for most form fields.',
+        story:
+          'Medium loader skeleton - the default size for most form fields.',
       },
     },
   },
@@ -70,7 +71,8 @@ export const Large: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Large loader skeleton for larger form sections or content areas.',
+        story:
+          'Large loader skeleton for larger form sections or content areas.',
       },
     },
   },

--- a/src/Utilities/functions.js
+++ b/src/Utilities/functions.js
@@ -18,84 +18,60 @@ const withNegatedFunction = (booleanFunctions) => {
   };
 };
 
+const hasLoosePermissions = async (
+  permissions = [],
+  { isV2Org = false, kesselMappedPermissions = [] } = {}
+) => {
+  if (isV2Org) {
+    const { mapV1PermissionToKesselRelation } = await import(
+      './kesselWorkspaceRelations'
+    );
+
+    return permissions.some((v1Permission) => {
+      const kesselRelation = mapV1PermissionToKesselRelation(v1Permission);
+
+      if (kesselRelation === 'UNMIGRATED') {
+        return true;
+      }
+
+      if (kesselRelation === null) {
+        return false;
+      }
+
+      return !!kesselMappedPermissions.find(
+        ({ permission }) => permission === v1Permission
+      );
+    });
+  } else {
+    const userPermissions = await insights.chrome.getUserPermissions();
+    return permissions.some((item) =>
+      userPermissions?.find(({ permission }) => permission === item)
+    );
+  }
+};
+
 export const visibilityFunctions = withNegatedFunction({
   ...insights.chrome?.visibilityFunctions,
-  hasLoosePermissions: async (permissions = []) => {
-    // Check if org is using RBAC v2 (Kessel)
-    // eslint-disable-next-line rulesdir/no-chrome-api-call-from-window
-    const isV2Org = window.insights?.chrome?._isRbacV2Org || false;
-
-    if (isV2Org) {
-      // Use Kessel permissions for v2 orgs
-      const kesselPermissions =
-        // eslint-disable-next-line rulesdir/no-chrome-api-call-from-window
-        window.insights?.chrome?._kesselMappedPermissions || [];
-
-      // Dynamic import to avoid circular dependency
-      const { mapV1PermissionToKesselRelation } = await import(
-        './kesselWorkspaceRelations'
-      );
-
-      // Check if user has any of the requested permissions
-      const hasPermission = permissions.some((v1Permission) => {
-        const kesselRelation = mapV1PermissionToKesselRelation(v1Permission);
-
-        // If permission is for an unmigrated app (e.g., insights:*:*), grant it
-        // This handles apps that haven't been migrated to v2 yet
-        if (kesselRelation === 'UNMIGRATED') {
-          console.log(
-            '[RBAC v2] Permission not migrated to v2, granting:',
-            v1Permission
-          );
-          return true;
-        }
-
-        // If permission doesn't map (unknown app), deny it
-        if (kesselRelation === null) {
-          console.log('[RBAC v2] Unknown permission, denying:', v1Permission);
-          return false;
-        }
-
-        // Check if user has the Kessel permission
-        const hasKesselPerm = kesselPermissions?.find(
-          ({ permission }) => permission === v1Permission
-        );
-
-        console.log(
-          '[RBAC v2] Permission check:',
-          v1Permission,
-          '→',
-          kesselRelation,
-          '→',
-          hasKesselPerm ? 'ALLOWED' : 'DENIED'
-        );
-
-        return !!hasKesselPerm;
-      });
-
-      return hasPermission;
-    } else {
-      // Use legacy v1 permissions
-      const userPermissions = await insights.chrome.getUserPermissions();
-      return permissions.some((item) =>
-        userPermissions?.find(({ permission }) => permission === item)
-      );
-    }
-  },
+  hasLoosePermissions,
 });
 
-export const calculatePermissions = (permissions) =>
+export const calculatePermissions = (permissions, rbacContext = {}) =>
   Promise.all(
-    [permissions]
-      .flat()
-      .map(({ method, args }) =>
-        visibilityFunctions?.[method]?.(...(args || []))
-      )
+    [permissions].flat().map(({ method, args }) => {
+      const fn = visibilityFunctions?.[method];
+      if (!fn) return false;
+      const isPermissionCheck =
+        method === 'hasLoosePermissions' || method === '!hasLoosePermissions';
+      return isPermissionCheck
+        ? fn(...(args || []), rbacContext)
+        : fn(...(args || []));
+    })
   ).then((visibility) => visibility.every(Boolean));
 
 export const calculateEmailConfig = (
   { 'email-preference': config } = { 'email-preference': {} },
-  dispatch = () => {}
+  dispatch = () => {},
+  rbacContext = {}
 ) =>
   Object.entries(config)
     .map(
@@ -104,7 +80,7 @@ export const calculateEmailConfig = (
         { permissions, url, apiName, apiVersion, localFile, ...rest },
       ]) => {
         const isVisible = permissions
-          ? calculatePermissions(permissions)
+          ? calculatePermissions(permissions, rbacContext)
           : true;
         (async () => {
           const schemaVisible = await Promise.resolve(isVisible);

--- a/src/Utilities/functions.test.js
+++ b/src/Utilities/functions.test.js
@@ -326,81 +326,73 @@ describe('dispatchMessages', () => {
 });
 
 describe('hasLoosePermissions with v2 (Kessel)', () => {
-  beforeEach(() => {
-    // Set up v2 org environment
-    global.insights.chrome._isRbacV2Org = true;
-    global.insights.chrome._kesselMappedPermissions = [
+  const v2Context = {
+    isV2Org: true,
+    kesselMappedPermissions: [
       { permission: 'advisor:*:read', resourceDefinitions: [] },
       { permission: 'user-preferences:*:write', resourceDefinitions: [] },
-    ];
-  });
-
-  afterEach(() => {
-    // Clean up
-    global.insights.chrome._isRbacV2Org = false;
-    global.insights.chrome._kesselMappedPermissions = [];
-  });
+    ],
+  };
 
   it('uses Kessel permissions for v2 org', async () => {
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'advisor:*:read',
-    ]);
+    const result = await visibilityFunctions.hasLoosePermissions(
+      ['advisor:*:read'],
+      v2Context
+    );
     expect(result).toBe(true);
   });
 
   it('returns false when permission not in Kessel list', async () => {
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'advisor:*:*', // User doesn't have advisor:*:* permission
-    ]);
+    const result = await visibilityFunctions.hasLoosePermissions(
+      ['advisor:*:*'],
+      v2Context
+    );
     expect(result).toBe(false);
   });
 
   it('returns true if any permission matches', async () => {
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'advisor:*:*', // Not granted
-      'advisor:*:read', // Granted
-    ]);
+    const result = await visibilityFunctions.hasLoosePermissions(
+      ['advisor:*:*', 'advisor:*:read'],
+      v2Context
+    );
     expect(result).toBe(true);
   });
 
   it('returns false when none of multiple permissions match', async () => {
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'other:*:read',
-      'another:*:write',
-      'missing:*:delete',
-    ]);
-    // All these are not in the Kessel mapped permissions list
+    const result = await visibilityFunctions.hasLoosePermissions(
+      ['other:*:read', 'another:*:write', 'missing:*:delete'],
+      v2Context
+    );
     expect(result).toBe(false);
   });
 
   it('returns false with empty Kessel permissions array', async () => {
-    global.insights.chrome._kesselMappedPermissions = [];
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'advisor:*:read',
-    ]);
+    const result = await visibilityFunctions.hasLoosePermissions(
+      ['advisor:*:read'],
+      { isV2Org: true, kesselMappedPermissions: [] }
+    );
     expect(result).toBe(false);
   });
 
   it('grants permissions for unmigrated apps (insights)', async () => {
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'insights:*:*', // Not migrated to v2, should be granted
-    ]);
+    const result = await visibilityFunctions.hasLoosePermissions(
+      ['insights:*:*'],
+      v2Context
+    );
     expect(result).toBe(true);
   });
 
   it('grants insights permissions even without Kessel perms', async () => {
-    global.insights.chrome._kesselMappedPermissions = [];
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'insights:*:read',
-    ]);
+    const result = await visibilityFunctions.hasLoosePermissions(
+      ['insights:*:read'],
+      { isV2Org: true, kesselMappedPermissions: [] }
+    );
     expect(result).toBe(true);
   });
 });
 
 describe('hasLoosePermissions with v1 (legacy)', () => {
   beforeEach(() => {
-    // Ensure v1 environment
-    global.insights.chrome._isRbacV2Org = false;
     global.insights.chrome.getUserPermissions.mockResolvedValue([
       { permission: 'insights:*:*', resourceDefinitions: [] },
       { permission: 'advisor:*:read', resourceDefinitions: [] },

--- a/src/Utilities/hooks/useDefaultWorkspace.ts
+++ b/src/Utilities/hooks/useDefaultWorkspace.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
-import { fetchDefaultWorkspace, Workspace } from '@project-kessel/react-kessel-access-check';
+import {
+  Workspace,
+  fetchDefaultWorkspace,
+} from '@project-kessel/react-kessel-access-check';
 
 /**
  * Hook to fetch and cache the default workspace ID.
@@ -18,7 +21,9 @@ export const useDefaultWorkspace = () => {
         // Use the current origin as the RBAC base endpoint
         const rbacBaseEndpoint = window.location.origin;
 
-        const workspace: Workspace = await fetchDefaultWorkspace(rbacBaseEndpoint);
+        const workspace: Workspace = await fetchDefaultWorkspace(
+          rbacBaseEndpoint
+        );
 
         if (isMounted) {
           setWorkspaceId(workspace.id);
@@ -26,7 +31,11 @@ export const useDefaultWorkspace = () => {
         }
       } catch (err) {
         if (isMounted) {
-          setError(err instanceof Error ? err : new Error('Failed to fetch default workspace'));
+          setError(
+            err instanceof Error
+              ? err
+              : new Error('Failed to fetch default workspace')
+          );
           setIsLoading(false);
         }
       }

--- a/src/Utilities/kesselRbac.test.ts
+++ b/src/Utilities/kesselRbac.test.ts
@@ -3,25 +3,39 @@ import { mapV1PermissionToKesselRelation } from './kesselWorkspaceRelations';
 describe('kesselRbac', () => {
   describe('mapV1PermissionToKesselRelation', () => {
     it('maps advisor wildcard permissions to v2 relations', () => {
-      expect(mapV1PermissionToKesselRelation('advisor:*:*')).toBe('advisor_all_all');
-      expect(mapV1PermissionToKesselRelation('advisor:*:read')).toBe('advisor_all_read');
-      expect(mapV1PermissionToKesselRelation('advisor:*:write')).toBe('advisor_all_write');
+      expect(mapV1PermissionToKesselRelation('advisor:*:*')).toBe(
+        'advisor_all_all'
+      );
+      expect(mapV1PermissionToKesselRelation('advisor:*:read')).toBe(
+        'advisor_all_read'
+      );
+      expect(mapV1PermissionToKesselRelation('advisor:*:write')).toBe(
+        'advisor_all_write'
+      );
     });
 
     it('maps advisor specific permissions to v2 relations', () => {
-      expect(mapV1PermissionToKesselRelation('advisor:rules:read')).toBe('advisor_rules_read');
-      expect(mapV1PermissionToKesselRelation('advisor:disable_recommendations:read')).toBe(
-        'advisor_disable_recommendations_view'
+      expect(mapV1PermissionToKesselRelation('advisor:rules:read')).toBe(
+        'advisor_rules_read'
       );
+      expect(
+        mapV1PermissionToKesselRelation('advisor:disable_recommendations:read')
+      ).toBe('advisor_disable_recommendations_view');
       expect(mapV1PermissionToKesselRelation('advisor:weekly_email:read')).toBe(
         'advisor_weekly_email_view'
       );
     });
 
     it('returns UNMIGRATED for insights permissions (not migrated)', () => {
-      expect(mapV1PermissionToKesselRelation('insights:*:*')).toBe('UNMIGRATED');
-      expect(mapV1PermissionToKesselRelation('insights:*:read')).toBe('UNMIGRATED');
-      expect(mapV1PermissionToKesselRelation('insights:some:read')).toBe('UNMIGRATED');
+      expect(mapV1PermissionToKesselRelation('insights:*:*')).toBe(
+        'UNMIGRATED'
+      );
+      expect(mapV1PermissionToKesselRelation('insights:*:read')).toBe(
+        'UNMIGRATED'
+      );
+      expect(mapV1PermissionToKesselRelation('insights:some:read')).toBe(
+        'UNMIGRATED'
+      );
     });
 
     it('returns null for invalid permission format', () => {
@@ -32,9 +46,9 @@ describe('kesselRbac', () => {
 
     it('generates relation names for unmapped advisor permissions', () => {
       // Should follow the pattern: app_resource_verb
-      expect(mapV1PermissionToKesselRelation('advisor:custom-resource:read')).toBe(
-        'advisor_custom_resource_read'
-      );
+      expect(
+        mapV1PermissionToKesselRelation('advisor:custom-resource:read')
+      ).toBe('advisor_custom_resource_read');
       expect(mapV1PermissionToKesselRelation('advisor:another:write')).toBe(
         'advisor_another_write'
       );

--- a/src/Utilities/kesselRbac.ts
+++ b/src/Utilities/kesselRbac.ts
@@ -1,5 +1,6 @@
-import React, { useEffect, useMemo, createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import { useSelfAccessCheck } from '@project-kessel/react-kessel-access-check';
+import type { SelfAccessCheckResourceWithRelation } from '@project-kessel/react-kessel-access-check';
 import { useDefaultWorkspace } from './hooks/useDefaultWorkspace';
 
 /**
@@ -29,171 +30,118 @@ export interface KesselPermissionResult {
  * Provides workspace ID and permission check results.
  */
 export interface KesselRbacAccessContextValue {
-  /**
-   * Default workspace ID from /api/rbac/v2/workspaces/?type=default
-   */
   workspaceId: string | undefined;
-
-  /**
-   * Whether the workspace and permissions are still loading
-   */
   isLoading: boolean;
-
-  /**
-   * Permission check results mapped to v1 format
-   */
   permissions: V1Permission[];
-
-  /**
-   * Raw Kessel permission check results
-   */
   kesselPermissions: KesselPermissionResult[];
-
-  /**
-   * Errors encountered during workspace or permission fetching
-   */
   errors: Error[];
 }
 
-export const KesselRbacAccessContext = createContext<KesselRbacAccessContextValue | undefined>(
-  undefined
-);
-
-/**
- * Hook to access Kessel RBAC context.
- * @throws if used outside KesselRbacAccessProvider
- */
-export const useKesselRbacAccess = (): KesselRbacAccessContextValue => {
-  const context = useContext(KesselRbacAccessContext);
-  if (!context) {
-    throw new Error('useKesselRbacAccess must be used within KesselRbacAccessProvider');
-  }
-  return context;
+const DEFAULT_CONTEXT: KesselRbacAccessContextValue = {
+  workspaceId: undefined,
+  isLoading: true,
+  permissions: [],
+  kesselPermissions: [],
+  errors: [],
 };
+
+export const KesselRbacAccessContext =
+  createContext<KesselRbacAccessContextValue>(DEFAULT_CONTEXT);
+
+export const useKesselRbacAccess = (): KesselRbacAccessContextValue => {
+  return useContext(KesselRbacAccessContext);
+};
+
+const ADVISOR_RELATIONS = [
+  'advisor_all_all',
+  'advisor_all_read',
+  'advisor_rules_read',
+] as const;
+
+type NonEmptyResources = [
+  SelfAccessCheckResourceWithRelation,
+  ...SelfAccessCheckResourceWithRelation[]
+];
+
+function mapRelationToV1Permission(relation: string): string {
+  const parts = relation.split('_');
+  if (parts.length === 3) {
+    const [app, resource, verb] = parts;
+    const v1Resource = resource === 'all' ? '*' : resource;
+    const v1Verb = verb === 'all' ? '*' : verb;
+    return `${app}:${v1Resource}:${v1Verb}`;
+  }
+  return relation;
+}
 
 /**
  * Provider for Kessel v2 RBAC.
  *
- * Fetches the default workspace and checks permissions for all required relations.
- * Stores results in context and global state for use by permission checking functions.
- *
- * Usage:
- * ```tsx
- * import { AccessCheck } from '@project-kessel/react-kessel-access-check';
- *
- * <AccessCheck.Provider baseUrl={window.location.origin} apiPath="/api/kessel/v1beta2">
- *   <KesselRbacAccessProvider>
- *     <App />
- *   </KesselRbacAccessProvider>
- * </AccessCheck.Provider>
- * ```
+ * Fetches the default workspace and checks all required permissions in a single
+ * bulk API call. When the workspace ID is not yet available, an empty resources
+ * array is passed so the hook completes immediately without an API call.
  */
 export const KesselRbacAccessProvider: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
-  // Fetch default workspace ID
   const {
     workspaceId,
     isLoading: workspaceLoading,
     error: workspaceError,
   } = useDefaultWorkspace();
 
-  // Build workspace resource for permission checks
-  const workspace = useMemo(() => {
+  const resources = useMemo<NonEmptyResources | undefined>(() => {
     if (!workspaceId) {
-      return {
-        id: '',
-        type: 'rbac/workspace' as const,
-        reporter: { type: 'rbac' as const },
-      };
+      return undefined;
     }
-    return {
+
+    return ADVISOR_RELATIONS.map((relation) => ({
       id: workspaceId,
       type: 'rbac/workspace' as const,
       reporter: { type: 'rbac' as const },
-    };
+      relation,
+    })) as NonEmptyResources;
   }, [workspaceId]);
 
-  // Check permissions for advisor wildcard permissions
-  const advisorAllAll = useSelfAccessCheck({
-    relation: 'advisor_all_all',
-    resource: workspace,
+  const bulkResult = useSelfAccessCheck({
+    resources: (resources ?? []) as NonEmptyResources,
   });
 
-  const advisorAllRead = useSelfAccessCheck({
-    relation: 'advisor_all_read',
-    resource: workspace,
-  });
-
-  const advisorRulesRead = useSelfAccessCheck({
-    relation: 'advisor_rules_read',
-    resource: workspace,
-  });
-
-  // Aggregate loading states
-  const isLoading =
-    workspaceLoading ||
-    advisorAllAll.loading ||
-    advisorAllRead.loading ||
-    advisorRulesRead.loading;
+  const isLoading = workspaceLoading || bulkResult.loading;
 
   const contextValue: KesselRbacAccessContextValue = useMemo(() => {
-    // Build raw Kessel permission results
-    const kesselPermissions: KesselPermissionResult[] = [
-      {
-        relation: 'advisor_all_all',
-        allowed: !!workspaceId && (advisorAllAll.data?.allowed ?? false),
-      },
-      {
-        relation: 'advisor_all_read',
-        allowed: !!workspaceId && (advisorAllRead.data?.allowed ?? false),
-      },
-      {
-        relation: 'advisor_rules_read',
-        allowed: !!workspaceId && (advisorRulesRead.data?.allowed ?? false),
-      },
-    ];
+    const kesselPermissions: KesselPermissionResult[] = ADVISOR_RELATIONS.map(
+      (relation) => {
+        const item = bulkResult.data?.find((d) => d.relation === relation);
+        return {
+          relation,
+          allowed: !!workspaceId && (item?.allowed ?? false),
+        };
+      }
+    );
 
-    // Map Kessel permissions to v1 format for backward compatibility
     const permissions: V1Permission[] = kesselPermissions
       .filter((kp) => kp.allowed)
-      .map((kp) => {
-        // Map relation name back to v1 permission format
-        // advisor_all_all → advisor:*:*
-        // advisor_all_read → advisor:*:read
-        // advisor_rules_read → advisor:rules:read
-        const parts = kp.relation.split('_');
-        if (parts.length === 3) {
-          const [app, resource, verb] = parts;
-          const v1Resource = resource === 'all' ? '*' : resource;
-          const v1Verb = verb === 'all' ? '*' : verb;
-          return {
-            permission: `${app}:${v1Resource}:${v1Verb}`,
-            resourceDefinitions: [],
-          };
-        }
-        return { permission: kp.relation, resourceDefinitions: [] };
-      });
+      .map((kp) => ({
+        permission: mapRelationToV1Permission(kp.relation),
+        resourceDefinitions: [],
+      }));
 
     const errors: Error[] = [];
     if (workspaceError) {
       errors.push(
-        new Error(`Workspace error: ${workspaceError.message || 'Unknown error'}`)
+        new Error(
+          `Workspace error: ${workspaceError.message || 'Unknown error'}`
+        )
       );
     }
-    if (advisorAllAll.error) {
+    if (bulkResult.error) {
       errors.push(
-        new Error(`Permission check error (advisor_all_all): ${advisorAllAll.error.message || 'Unknown error'}`)
-      );
-    }
-    if (advisorAllRead.error) {
-      errors.push(
-        new Error(`Permission check error (advisor_all_read): ${advisorAllRead.error.message || 'Unknown error'}`)
-      );
-    }
-    if (advisorRulesRead.error) {
-      errors.push(
-        new Error(`Permission check error (advisor_rules_read): ${advisorRulesRead.error.message || 'Unknown error'}`)
+        new Error(
+          `Permission check error: ${
+            bulkResult.error.message || 'Unknown error'
+          }`
+        )
       );
     }
 
@@ -208,24 +156,9 @@ export const KesselRbacAccessProvider: React.FC<{
     workspaceId,
     isLoading,
     workspaceError,
-    advisorAllAll.data?.allowed,
-    advisorAllAll.error,
-    advisorAllRead.data?.allowed,
-    advisorAllRead.error,
-    advisorRulesRead.data?.allowed,
-    advisorRulesRead.error,
+    bulkResult.data,
+    bulkResult.error,
   ]);
-
-  // Inject into global state for backward compatibility with functions.js
-  useEffect(() => {
-    // eslint-disable-next-line rulesdir/no-chrome-api-call-from-window
-    if (window.insights?.chrome) {
-      // eslint-disable-next-line rulesdir/no-chrome-api-call-from-window
-      (window.insights.chrome as any)._kesselPermissions = contextValue.kesselPermissions;
-      // eslint-disable-next-line rulesdir/no-chrome-api-call-from-window
-      (window.insights.chrome as any)._kesselMappedPermissions = contextValue.permissions;
-    }
-  }, [contextValue]);
 
   return React.createElement(
     KesselRbacAccessContext.Provider,

--- a/src/Utilities/kesselWorkspaceRelations.ts
+++ b/src/Utilities/kesselWorkspaceRelations.ts
@@ -35,16 +35,20 @@ export const mapV1PermissionToKesselRelation = (
 
     // Advisor specific permissions from advisor.ksl
     'advisor:rules:read': 'advisor_rules_read',
-    'advisor:disable_recommendations:read': 'advisor_disable_recommendations_view',
-    'advisor:disable_recommendations:write': 'advisor_disable_recommendations_edit',
+    'advisor:disable_recommendations:read':
+      'advisor_disable_recommendations_view',
+    'advisor:disable_recommendations:write':
+      'advisor_disable_recommendations_edit',
     'advisor:weekly_email:read': 'advisor_weekly_email_view',
     'advisor:weekly_report:read': 'advisor_weekly_report_view',
     'advisor:weekly_report_auto_subscribe:read':
       'advisor_weekly_report_auto_subscribe_view',
     'advisor:weekly_report_auto_subscribe:write':
       'advisor_weekly_report_auto_subscribe_edit',
-    'advisor:recommendation_results:read': 'advisor_recommendation_results_view',
-    'advisor:recommendation_results:write': 'advisor_recommendation_results_edit',
+    'advisor:recommendation_results:read':
+      'advisor_recommendation_results_view',
+    'advisor:recommendation_results:write':
+      'advisor_recommendation_results_edit',
     'advisor:exports:read': 'advisor_exports_view',
   };
 
@@ -70,7 +74,8 @@ export const mapV1PermissionToKesselRelation = (
     // Convert verb: read→read, write→write, *→all
     const kesselVerb = verb === '*' ? 'all' : verb;
     // Convert resource: *→all, kebab-case→snake_case otherwise
-    const kesselResource = resource === '*' ? 'all' : resource.replace(/-/g, '_');
+    const kesselResource =
+      resource === '*' ? 'all' : resource.replace(/-/g, '_');
 
     return `${app}_${kesselResource}_${kesselVerb}`;
   }


### PR DESCRIPTION
## Summary
- Replace 3 individual `useSelfAccessCheck` calls with a single bulk `checkselfbulk` request, passing an empty resources array when workspace ID is not yet available to prevent 400 errors
- Remove `window.insights.chrome._kesselPermissions` global injection — pass permissions as parameters through `calculateEmailConfig` instead
- Extend eslint TS parser override to all `.ts`/`.tsx` files

## JIRA
[RHCLOUD-49223](https://redhat.atlassian.net/browse/RHCLOUD-49223)

## Test plan
- [ ] Log in as a v2 user, navigate to `/user-preferences/notifications`
- [ ] Verify no 400 errors against `/api/kessel/v1beta2/checkself` in the Network tab
- [ ] Verify a single `checkselfbulk` request fires instead of 3 individual `checkself` calls
- [ ] Verify no reads from `window.insights.chrome._kesselPermissions`
- [ ] Verify notification preferences page loads and functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-49223]: https://redhat.atlassian.net/browse/RHCLOUD-49223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ