### PR TITLE
fix: remove per-org v2 gating — use global Kessel access checks

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -15,7 +15,7 @@ if (!global.crypto.randomUUID) {
 }
 
 jest.mock('@unleash/proxy-client-react', () => ({
-  useFlag: jest.fn(() => false), // Default to v1 org
+  useFlag: jest.fn(() => false),
 }));
 
 // Mock Kessel SDK
@@ -40,10 +40,6 @@ global.insights = {
         { permission: 'user-preferences:*:*', resourceDefinitions: [] },
       ])
     ),
-    // Mock v2 properties
-    _isRbacV2Org: false,
-    _kesselPermissions: [],
-    _kesselMappedPermissions: [],
   },
 };
 global.ResizeObserver = jest.fn().mockImplementation(() => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,11 @@ import React, { Fragment, useEffect } from 'react';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import { useFlag } from '@unleash/proxy-client-react';
 import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 import './App.scss';
 import Routing from './Routing';
 import { KesselRbacAccessProvider } from './Utilities/kesselRbac';
 
-/**
- * Inner app component - handles auth and routing
- * Separated to allow Kessel provider to wrap it
- */
 const AppInner: React.FC = () => {
   const { auth, updateDocumentTitle } = useChrome();
 
@@ -39,24 +34,8 @@ const AppInner: React.FC = () => {
   );
 };
 
-/**
- * Version router: reads the platform.rbac.workspaces flag and renders with or without Kessel providers.
- * This matches the pattern from insights-rbac-ui/src/Iam.tsx
- */
-const VersionRouter: React.FC = () => {
-  const hasRbacV2 = useFlag('platform.rbac.workspaces');
-
-  // Make v2 flag available to functions.js
-  useEffect(() => {
-    // eslint-disable-next-line rulesdir/no-chrome-api-call-from-window
-    if (window.insights?.chrome) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, rulesdir/no-chrome-api-call-from-window
-      (window.insights.chrome as any)._isRbacV2Org = hasRbacV2;
-    }
-  }, [hasRbacV2]);
-
-  return hasRbacV2 ? (
-    // RBAC v2: Wrap with Kessel providers
+const App: React.FC = () => {
+  return (
     <AccessCheck.Provider
       baseUrl={window.location.origin}
       apiPath="/api/kessel/v1beta2"
@@ -65,17 +44,7 @@ const VersionRouter: React.FC = () => {
         <AppInner />
       </KesselRbacAccessProvider>
     </AccessCheck.Provider>
-  ) : (
-    // RBAC v1: No Kessel providers needed
-    <AppInner />
   );
-};
-
-/**
- * Main application entry point.
- */
-const App: React.FC = () => {
-  return <VersionRouter />;
 };
 
 export default App;

--- a/src/PresentationalComponents/Notifications/Notifications.js
+++ b/src/PresentationalComponents/Notifications/Notifications.js
@@ -3,6 +3,7 @@ import omit from 'lodash/omit';
 import { useFlag } from '@unleash/proxy-client-react';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useKesselRbacAccess } from '../../Utilities/kesselRbac';
+
 import { FormRenderer } from '@data-driven-forms/react-form-renderer';
 import { componentMapper } from '@data-driven-forms/pf4-component-mapper';
 import { Bullseye, Button, Popover, Spinner } from '@patternfly/react-core';
@@ -176,7 +177,6 @@ const Notifications = () => {
     PLATFORM_NOTIFICATIONS_SEVERITY_FLAG
   );
   const isVAEnabled = useFlag('platform.va.environment.enabled');
-  const isV2Org = useFlag('platform.rbac.workspaces');
   const { auth } = useChrome();
   const { permissions: kesselMappedPermissions } = useKesselRbacAccess();
   const dispatch = useDispatch();
@@ -204,7 +204,6 @@ const Notifications = () => {
       await auth.getUser();
       setEmailConfig(
         calculateEmailConfig(config, dispatch, {
-          isV2Org,
           kesselMappedPermissions,
         })
       );
@@ -252,7 +251,6 @@ const Notifications = () => {
         submitEmail &&
           setEmailConfig(
             calculateEmailConfig(config, dispatch, {
-              isV2Org,
               kesselMappedPermissions,
             })
           );

--- a/src/PresentationalComponents/Notifications/Notifications.stories.tsx
+++ b/src/PresentationalComponents/Notifications/Notifications.stories.tsx
@@ -155,29 +155,3 @@ export const SeverityHelpOff = {
     ).not.toBeInTheDocument();
   },
 } satisfies StoryObj<typeof meta>;
-
-export const RbacV2Org = {
-  name: 'With RBAC v2 (Kessel)',
-  render: () => <Notifications />,
-  parameters: {
-    featureFlags: {
-      'platform.rbac.workspaces': true, // Enable v2 org
-      'platform.notifications.severity': true,
-    },
-    chrome: {
-      _isRbacV2Org: true,
-    },
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await canvas.findByText(
-      /Possible notification severity levels include/i,
-      {},
-      { timeout: 10000 }
-    );
-    // Verify page loads correctly with Kessel permissions
-    await expect(
-      canvas.getByRole('button', { name: 'Critical' })
-    ).toBeInTheDocument();
-  },
-} satisfies StoryObj<typeof meta>;

--- a/src/Utilities/functions.js
+++ b/src/Utilities/functions.js
@@ -20,34 +20,27 @@ const withNegatedFunction = (booleanFunctions) => {
 
 const hasLoosePermissions = async (
   permissions = [],
-  { isV2Org = false, kesselMappedPermissions = [] } = {}
+  { kesselMappedPermissions = [] } = {}
 ) => {
-  if (isV2Org) {
-    const { mapV1PermissionToKesselRelation } = await import(
-      './kesselWorkspaceRelations'
+  const { mapV1PermissionToKesselRelation } = await import(
+    './kesselWorkspaceRelations'
+  );
+
+  return permissions.some((v1Permission) => {
+    const kesselRelation = mapV1PermissionToKesselRelation(v1Permission);
+
+    if (kesselRelation === 'UNMIGRATED') {
+      return true;
+    }
+
+    if (kesselRelation === null) {
+      return false;
+    }
+
+    return !!kesselMappedPermissions.find(
+      ({ permission }) => permission === v1Permission
     );
-
-    return permissions.some((v1Permission) => {
-      const kesselRelation = mapV1PermissionToKesselRelation(v1Permission);
-
-      if (kesselRelation === 'UNMIGRATED') {
-        return true;
-      }
-
-      if (kesselRelation === null) {
-        return false;
-      }
-
-      return !!kesselMappedPermissions.find(
-        ({ permission }) => permission === v1Permission
-      );
-    });
-  } else {
-    const userPermissions = await insights.chrome.getUserPermissions();
-    return permissions.some((item) =>
-      userPermissions?.find(({ permission }) => permission === item)
-    );
-  }
+  });
 };
 
 export const visibilityFunctions = withNegatedFunction({

--- a/src/Utilities/functions.test.js
+++ b/src/Utilities/functions.test.js
@@ -325,19 +325,18 @@ describe('dispatchMessages', () => {
   });
 });
 
-describe('hasLoosePermissions with v2 (Kessel)', () => {
-  const v2Context = {
-    isV2Org: true,
+describe('hasLoosePermissions', () => {
+  const kesselContext = {
     kesselMappedPermissions: [
       { permission: 'advisor:*:read', resourceDefinitions: [] },
       { permission: 'user-preferences:*:write', resourceDefinitions: [] },
     ],
   };
 
-  it('uses Kessel permissions for v2 org', async () => {
+  it('uses Kessel permissions', async () => {
     const result = await visibilityFunctions.hasLoosePermissions(
       ['advisor:*:read'],
-      v2Context
+      kesselContext
     );
     expect(result).toBe(true);
   });
@@ -345,7 +344,7 @@ describe('hasLoosePermissions with v2 (Kessel)', () => {
   it('returns false when permission not in Kessel list', async () => {
     const result = await visibilityFunctions.hasLoosePermissions(
       ['advisor:*:*'],
-      v2Context
+      kesselContext
     );
     expect(result).toBe(false);
   });
@@ -353,7 +352,7 @@ describe('hasLoosePermissions with v2 (Kessel)', () => {
   it('returns true if any permission matches', async () => {
     const result = await visibilityFunctions.hasLoosePermissions(
       ['advisor:*:*', 'advisor:*:read'],
-      v2Context
+      kesselContext
     );
     expect(result).toBe(true);
   });
@@ -361,7 +360,7 @@ describe('hasLoosePermissions with v2 (Kessel)', () => {
   it('returns false when none of multiple permissions match', async () => {
     const result = await visibilityFunctions.hasLoosePermissions(
       ['other:*:read', 'another:*:write', 'missing:*:delete'],
-      v2Context
+      kesselContext
     );
     expect(result).toBe(false);
   });
@@ -369,7 +368,7 @@ describe('hasLoosePermissions with v2 (Kessel)', () => {
   it('returns false with empty Kessel permissions array', async () => {
     const result = await visibilityFunctions.hasLoosePermissions(
       ['advisor:*:read'],
-      { isV2Org: true, kesselMappedPermissions: [] }
+      { kesselMappedPermissions: [] }
     );
     expect(result).toBe(false);
   });
@@ -377,7 +376,7 @@ describe('hasLoosePermissions with v2 (Kessel)', () => {
   it('grants permissions for unmigrated apps (insights)', async () => {
     const result = await visibilityFunctions.hasLoosePermissions(
       ['insights:*:*'],
-      v2Context
+      kesselContext
     );
     expect(result).toBe(true);
   });
@@ -385,32 +384,8 @@ describe('hasLoosePermissions with v2 (Kessel)', () => {
   it('grants insights permissions even without Kessel perms', async () => {
     const result = await visibilityFunctions.hasLoosePermissions(
       ['insights:*:read'],
-      { isV2Org: true, kesselMappedPermissions: [] }
+      { kesselMappedPermissions: [] }
     );
     expect(result).toBe(true);
-  });
-});
-
-describe('hasLoosePermissions with v1 (legacy)', () => {
-  beforeEach(() => {
-    global.insights.chrome.getUserPermissions.mockResolvedValue([
-      { permission: 'insights:*:*', resourceDefinitions: [] },
-      { permission: 'advisor:*:read', resourceDefinitions: [] },
-    ]);
-  });
-
-  it('uses legacy getUserPermissions for v1 org', async () => {
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'advisor:*:read',
-    ]);
-    expect(result).toBe(true);
-    expect(global.insights.chrome.getUserPermissions).toHaveBeenCalled();
-  });
-
-  it('returns false when permission not in v1 list', async () => {
-    const result = await visibilityFunctions.hasLoosePermissions([
-      'other:*:read',
-    ]);
-    expect(result).toBe(false);
   });
 });

--- a/src/Utilities/kesselRbac.ts
+++ b/src/Utilities/kesselRbac.ts
@@ -97,7 +97,7 @@ export const KesselRbacAccessProvider: React.FC<{
 
     return ADVISOR_RELATIONS.map((relation) => ({
       id: workspaceId,
-      type: 'rbac/workspace' as const,
+      type: 'workspace' as const,
       reporter: { type: 'rbac' as const },
       relation,
     })) as NonEmptyResources;


### PR DESCRIPTION
## Summary
- Remove `platform.rbac.workspaces` per-org feature flag gating from Kessel v2 access checks — v2 checks are now called globally for all orgs
- Always mount Kessel providers (`AccessCheck.Provider`, `KesselRbacAccessProvider`) instead of conditionally based on the workspace flag
- Remove v1 `getUserPermissions` fallback from `hasLoosePermissions` — always use the Kessel permission path
- Fix `resource_type` from `rbac/workspace` to `workspace` to pass Kessel API validation (`^[A-Za-z0-9_]+$`)
- Remove `_isRbacV2Org` `window.insights` side-effect and redundant `RbacV2Org` story

## Context
Under dual-write, v2 permission checks return the same results as v1 for all orgs, so per-org gating is unnecessary. The workspace flag should only gate the v2 UX experience, not API call routing. FedRAMP/environment-level fallback will be handled at the platform level (Chrome/SDK), not per-app.

Resolves: [RHCLOUD-49447](https://redhat.atlassian.net/browse/RHCLOUD-49447)
Related: [RHCLOUD-49463](https://redhat.atlassian.net/browse/RHCLOUD-49463)

## Test plan
- [ ] Verify app loads without errors on local dev (`npm start`)
- [ ] Verify `/api/rbac/v2/workspaces/` and `/api/kessel/v1beta2/checkselfbulk` requests succeed (no 400 validation errors)
- [ ] Verify notification preferences page renders correctly with Kessel permissions
- [ ] Verify email preference visibility (Advisor section) works via Kessel permission checks
- [ ] Run `npm test` — all 110 tests pass
- [ ] Run `npm run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-49447]: https://redhat.atlassian.net/browse/RHCLOUD-49447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHCLOUD-49463]: https://redhat.atlassian.net/browse/RHCLOUD-49463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ