### PR TITLE
fix(menu): glass theme issues in user preferences menu

### DIFF
--- a/src/PresentationalComponents/Notifications/notifications.scss
+++ b/src/PresentationalComponents/Notifications/notifications.scss
@@ -1,7 +1,6 @@
 .pref-notifications {
   &--container {
     height: 100%;
-    background-color: var(--pf-t--global--color--background--secondary);
   }
   &--wrapper {
     display: block;
@@ -25,11 +24,26 @@
     grid-area: nav;
     border-right: 1px solid var(--pf-t--global--color--border--default);
     overflow: visible;
+    background: var(--pf-t--global--background--color--primary--default);
+
+    // Ensure Menu component and search inside nav get glass treatment
+    .pf-v6-c-menu,
+    .pf-v6-c-menu__search,
+    .pf-v6-c-menu__content {
+      background: transparent;
+    }
+
+    // Make menu item highlights semi-transparent for glass effect
+    .pf-v6-c-menu__list-item {
+      &.pf-m-focus,
+      &.pf-m-focused {
+        background-color: var(--pf-t--global--background--color--action--hover--default);
+      }
+    }
   }
   &--inputs {
     grid-area: inputs;
     padding: var(--pf-t--global--spacer--lg);
-    background-color: var(--pf-t--global--color--background--secondary);
     overflow: visible;
   }
   &--severity-term {


### PR DESCRIPTION
Glass theme was not being applied to the preferences menu 

Before: 
<img width="319" height="653" alt="Screenshot From 2026-07-22 14-47-37" src="https://github.com/user-attachments/assets/d6e6d7f5-7a38-453b-8e45-a0778822b97e" />


After:
<img width="310" height="653" alt="Screenshot From 2026-07-22 14-46-12" src="https://github.com/user-attachments/assets/0498aac5-6f5a-4a7d-87ba-47791ad3377d" />
