### PR TITLE
Add org admin custom threshold tooltip

### DIFF
--- a/src/PresentationalComponents/Notifications/Notifications.js
+++ b/src/PresentationalComponents/Notifications/Notifications.js
@@ -4,6 +4,7 @@ import { useFlag } from '@unleash/proxy-client-react';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useKesselRbacAccess } from '../../Utilities/kesselRbac';
 import { useCustomThreshold } from '../../Utilities/hooks/useCustomThreshold';
+import { useIsOrgAdmin } from '../../Utilities/hooks/useIsOrgAdmin';
 import { FormRenderer } from '@data-driven-forms/react-form-renderer';
 import { componentMapper } from '@data-driven-forms/pf4-component-mapper';
 import { Bullseye, Button, Popover, Spinner } from '@patternfly/react-core';
@@ -181,6 +182,7 @@ const Notifications = () => {
   const { auth } = useChrome();
   const { permissions: kesselMappedPermissions } = useKesselRbacAccess();
   const { threshold: customThreshold } = useCustomThreshold();
+  const { isOrgAdmin } = useIsOrgAdmin();
   const dispatch = useDispatch();
   const { addNotification } = useNotifications();
   const titleRef = useRef(null);
@@ -353,7 +355,8 @@ const Notifications = () => {
                     emailPref,
                     emailConfig,
                     platformNotificationsSeverity,
-                    customThreshold
+                    customThreshold,
+                    isOrgAdmin
                   ),
                 },
               ],

--- a/src/PresentationalComponents/Notifications/utils.js
+++ b/src/PresentationalComponents/Notifications/utils.js
@@ -62,13 +62,15 @@ const afterChange = (formOptions, newValue, bundle, app) => {
  * @param {Record<string, unknown>} emailConfig
  * @param {boolean} [enableSeveritySubscriptionGrid=false] Unleash `platform.notifications.severity` — when true, event types that expose a severity grid render the severity subscription grid component.
  * @param {number} [customThreshold] Custom threshold percentage from org preferences
+ * @param {boolean} [isOrgAdmin=false] Whether the user is an organization administrator
  */
 export const prepareFields = (
   notifPref,
   emailPref,
   emailConfig,
   enableSeveritySubscriptionGrid = false,
-  customThreshold
+  customThreshold,
+  isOrgAdmin = false
 ) =>
   Object.entries(notifPref).reduce((acc, [bundleKey, bundleData]) => {
     return [
@@ -235,8 +237,9 @@ export const prepareFields = (
                           customThreshold !== undefined
                         ) {
                           cardProps.description = `Custom percentage has been set to ${customThreshold}%`;
-                          cardProps.helpText =
-                            'Please contact your admin if you have any question regarding the custom percentage.';
+                          cardProps.helpText = isOrgAdmin
+                            ? 'The custom percentage can be updated through Configure Events page.'
+                            : 'Please contact your admin if you have any question regarding the custom percentage.';
                         }
 
                         return cardProps;

--- a/src/PresentationalComponents/Notifications/utils.test.js
+++ b/src/PresentationalComponents/Notifications/utils.test.js
@@ -293,4 +293,102 @@ describe('prepareFields', () => {
     expect(instantField.description).toBeUndefined();
     expect(drawerField.description).toBeUndefined();
   });
+
+  it('sets non-admin help text for custom threshold when isOrgAdmin is false', () => {
+    const notifPref = {
+      subscriptions: {
+        label: 'Subscriptions',
+        applications: {
+          usage: {
+            label: 'Usage',
+            eventTypes: [
+              {
+                name: 'CUSTOM_THRESHOLD',
+                label: 'Custom subscription threshold exceeded',
+                fields: [
+                  {
+                    name: 'bundles[subscriptions].applications[usage].eventTypes[CUSTOM_THRESHOLD].emailSubscriptionTypes[INSTANT]',
+                    label: 'Instant notification',
+                    severities: [
+                      {
+                        name: 'MODERATE',
+                        initialValue: false,
+                        disabled: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
+    const result = prepareFields(
+      notifPref,
+      {},
+      {},
+      true,
+      85,
+      false // isOrgAdmin = false
+    );
+    const tab = result[0].fields[0];
+    const eventInput = tab.fields.find((f) => f.name === 'event-notifications');
+    const eventCard = eventInput.fields[0];
+
+    expect(eventCard.eventLabel).toBe('Usage at custom percentage');
+    expect(eventCard.description).toBe('Custom percentage has been set to 85%');
+    expect(eventCard.helpText).toBe(
+      'Please contact your admin if you have any question regarding the custom percentage.'
+    );
+  });
+
+  it('sets admin help text for custom threshold when isOrgAdmin is true', () => {
+    const notifPref = {
+      subscriptions: {
+        label: 'Subscriptions',
+        applications: {
+          usage: {
+            label: 'Usage',
+            eventTypes: [
+              {
+                name: 'CUSTOM_THRESHOLD',
+                label: 'Custom subscription threshold exceeded',
+                fields: [
+                  {
+                    name: 'bundles[subscriptions].applications[usage].eventTypes[CUSTOM_THRESHOLD].emailSubscriptionTypes[INSTANT]',
+                    label: 'Instant notification',
+                    severities: [
+                      {
+                        name: 'MODERATE',
+                        initialValue: false,
+                        disabled: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
+    const result = prepareFields(
+      notifPref,
+      {},
+      {},
+      true,
+      85,
+      true // isOrgAdmin = true
+    );
+    const tab = result[0].fields[0];
+    const eventInput = tab.fields.find((f) => f.name === 'event-notifications');
+    const eventCard = eventInput.fields[0];
+
+    expect(eventCard.eventLabel).toBe('Usage at custom percentage');
+    expect(eventCard.description).toBe('Custom percentage has been set to 85%');
+    expect(eventCard.helpText).toBe(
+      'The custom percentage can be updated through Configure Events page.'
+    );
+  });
 });

--- a/src/SmartComponents/FormComponents/NotificationEventCard.stories.tsx
+++ b/src/SmartComponents/FormComponents/NotificationEventCard.stories.tsx
@@ -327,12 +327,12 @@ export const WithDescriptionAndHelpIcon = {
       <CardBody>
         <Content>
           <Title headingLevel="h2">
-            Usage at custom percentage event with help icon
+            Usage at custom percentage (non-admin view)
           </Title>
           <p>
-            This example demonstrates the usage at custom percentage event with
-            a help icon tooltip and a description showing the configured
-            threshold percentage.
+            This example demonstrates the usage at custom percentage event for
+            non-admin users with a help icon that tells them to contact their
+            admin.
           </p>
         </Content>
         <FormRenderer
@@ -370,6 +370,65 @@ export const WithDescriptionAndHelpIcon = {
                 description: 'Custom percentage has been set to 85%',
                 helpText:
                   'Please contact your admin if you have any question regarding the custom percentage.',
+              },
+            ],
+          }}
+          onSubmit={(values) => console.log('Form submitted:', values)}
+        />
+      </CardBody>
+    </Card>
+  ),
+};
+
+export const WithDescriptionAndHelpIconAdmin = {
+  render: () => (
+    <Card>
+      <CardBody>
+        <Content>
+          <Title headingLevel="h2">
+            Usage at custom percentage (admin view)
+          </Title>
+          <p>
+            This example demonstrates the usage at custom percentage event for
+            admin users with a help icon that directs them to Configure Events
+            page.
+          </p>
+        </Content>
+        <FormRenderer
+          componentMapper={{
+            ...componentMapper,
+            [NOTIFICATION_EVENT_CARD]: NotificationEventCard,
+          }}
+          FormTemplate={FormTemplate}
+          schema={{
+            fields: [
+              {
+                name: 'bundles[subscriptions].applications[usage].eventTypes[CUSTOM_THRESHOLD]',
+                component: NOTIFICATION_EVENT_CARD,
+                eventName: 'CUSTOM_THRESHOLD',
+                eventLabel: 'Usage at custom percentage',
+                severity: 'MODERATE',
+                subscriptionFields: [
+                  {
+                    name: 'INSTANT',
+                    label: 'Instant notification',
+                    initialValue: false,
+                  },
+                  {
+                    name: 'DRAWER',
+                    label: 'Drawer notification',
+                    initialValue: false,
+                  },
+                ],
+                bundle: 'subscriptions',
+                app: 'usage',
+                initialValue: {
+                  INSTANT: false,
+                  DRAWER: false,
+                },
+                description: 'Custom percentage has been set to 85%',
+                helpText:
+                  'The custom percentage can be updated through Configure Events page.',
               },
             ],
           }}

--- a/src/SmartComponents/FormComponents/NotificationEventCard.test.tsx
+++ b/src/SmartComponents/FormComponents/NotificationEventCard.test.tsx
@@ -227,4 +227,106 @@ describe('NotificationEventCard tests', () => {
 
     expect(afterChangeMock).toHaveBeenCalled();
   });
+
+  it('should render description when provided', () => {
+    render(
+      <Form onSubmit={() => undefined}>
+        {(props) => (
+          <RendererContext.Provider
+            value={
+              {
+                formOptions: {
+                  internalRegisterField: () => undefined,
+                  internalUnRegisterField: () => undefined,
+                } as any,
+              } as any
+            }
+          >
+            <NotificationEventCard
+              name="test-event"
+              eventName="CUSTOM_THRESHOLD"
+              eventLabel="Usage at custom percentage"
+              subscriptionFields={sampleFields}
+              bundle="subscriptions"
+              app="usage"
+              description="Custom percentage has been set to 85%"
+              {...(props as any)}
+            />
+          </RendererContext.Provider>
+        )}
+      </Form>
+    );
+
+    expect(
+      screen.getByText('Custom percentage has been set to 85%')
+    ).toBeInTheDocument();
+  });
+
+  it('should render help icon with tooltip for non-admin', () => {
+    render(
+      <Form onSubmit={() => undefined}>
+        {(props) => (
+          <RendererContext.Provider
+            value={
+              {
+                formOptions: {
+                  internalRegisterField: () => undefined,
+                  internalUnRegisterField: () => undefined,
+                } as any,
+              } as any
+            }
+          >
+            <NotificationEventCard
+              name="test-event"
+              eventName="CUSTOM_THRESHOLD"
+              eventLabel="Usage at custom percentage"
+              subscriptionFields={sampleFields}
+              bundle="subscriptions"
+              app="usage"
+              helpText="Please contact your admin if you have any question regarding the custom percentage."
+              {...(props as any)}
+            />
+          </RendererContext.Provider>
+        )}
+      </Form>
+    );
+
+    // Help icon should be present
+    const helpIcon = screen.getByRole('img', { hidden: true });
+    expect(helpIcon).toBeInTheDocument();
+  });
+
+  it('should render help icon with tooltip for admin', () => {
+    render(
+      <Form onSubmit={() => undefined}>
+        {(props) => (
+          <RendererContext.Provider
+            value={
+              {
+                formOptions: {
+                  internalRegisterField: () => undefined,
+                  internalUnRegisterField: () => undefined,
+                } as any,
+              } as any
+            }
+          >
+            <NotificationEventCard
+              name="test-event"
+              eventName="CUSTOM_THRESHOLD"
+              eventLabel="Usage at custom percentage"
+              subscriptionFields={sampleFields}
+              bundle="subscriptions"
+              app="usage"
+              helpText="The custom percentage can be updated through Configure Events page."
+              {...(props as any)}
+            />
+          </RendererContext.Provider>
+        )}
+      </Form>
+    );
+
+    // Help icon should be present
+    const helpIcon = screen.getByRole('img', { hidden: true });
+    expect(helpIcon).toBeInTheDocument();
+  });
 });

--- a/src/Utilities/hooks/useIsOrgAdmin.ts
+++ b/src/Utilities/hooks/useIsOrgAdmin.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+
+/**
+ * Hook to check if the current user is an organization administrator.
+ * @returns boolean indicating if the user is an org admin
+ */
+export const useIsOrgAdmin = () => {
+  const [isOrgAdmin, setIsOrgAdmin] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const { auth } = useChrome();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const checkOrgAdmin = async () => {
+      try {
+        const user = await auth.getUser();
+        if (isMounted) {
+          // Check user.identity.user.is_org_admin from the identity object
+          setIsOrgAdmin(Boolean(user?.identity?.user?.is_org_admin));
+          setIsLoading(false);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setIsOrgAdmin(false);
+          setIsLoading(false);
+        }
+      }
+    };
+
+    checkOrgAdmin();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [auth]);
+
+  return {
+    isOrgAdmin,
+    isLoading,
+  };
+};

--- a/src/__mocks__/@redhat-cloud-services/frontend-components/useChrome/index.js
+++ b/src/__mocks__/@redhat-cloud-services/frontend-components/useChrome/index.js
@@ -1,6 +1,13 @@
 const useChrome = () => {
   const auth = {
-    getUser: () => Promise.resolve({ identity: {} }),
+    getUser: () =>
+      Promise.resolve({
+        identity: {
+          user: {
+            is_org_admin: false,
+          },
+        },
+      }),
   };
 
   return {


### PR DESCRIPTION
Adds org admin tooltip and keeps current tooltip for non-org admins

<img width="481" height="237" alt="Screenshot 2026-07-30 at 8 35 41 AM" src="https://github.com/user-attachments/assets/df137399-7d9b-4156-9082-0b4681ab1c17" />
